### PR TITLE
CSS-5136 Postgresql improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,7 @@ juju deploy ./superset-k8s_ubuntu-22.04-amd64.charm --resource superset-image=ap
 juju status
 ```
 ## Relations
+### Redis
 Redis acts as both a cache and message broker for Superset services. It's a requirement to have a redis relation in order to start the Superset application.
 ```
 # deploy redis charm
@@ -88,6 +89,23 @@ juju remove-relation redis-k8s superset-k8s
 juju remove-application redis-k8s
 ```
 The recommended method for relating applications to the Redis Charm is using the `redis-k8s.v0.redis` library, and utilising stored state for accessing relation data. There is an [issue](https://github.com/canonical/redis-k8s-operator/issues/74) for updating this to use the data interfaces library in future.
+
+### PostgreSQL
+PostgreSQL is used as the database that stores Superset metadata (slices, connections, tables, dashboards etc.). It's a requirement to have a PostgreSQL relation to start the Superset application.
+```
+# deploy postgresql charm
+juju deploy postgresql-k8s --channel 14/stable
+
+# relate postgresql charm
+juju relate postgresql-k8s superset-k8s
+
+# remove relation
+juju remove-relation postgresql-k8s superset-k8s
+
+# remove application
+juju remove-application postgresql-k8s
+```
+This relation makes use of the `data_platform_libs.v0.data_interfaces` library. The charm can be found on [Charmhub](https://charmhub.io/postgresql-k8s) and on [github](https://github.com/canonical/postgresql-k8s-operator).
 
 ## Cleanup
 # Remove the application before retrying

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ juju deploy redis-k8s --edge
 # relate redis charm
 juju relate redis-k8s superset-k8s
 ```
+### PostgreSQL
+PostgreSQL is used as the database that stores Superset metadata (slices, connections, tables, dashboards etc.). It's a requirement to have a PostgreSQL relation to start the Superset application.
+```
+# deploy postgresql charm
+juju deploy postgresql-k8s --channel 14/stable
+
+# relate postgresql charm
+juju relate postgresql-k8s superset-k8s
+```
 
 ### Ingress
 The Superset operator exposes its ports using the Nginx Ingress Integrator operator. You must first make sure to have an Nginx Ingress Controller deployed. To enable TLS connections, you must have a TLS certificate stored as a k8s secret (default name is "superset-tls"). A self-signed certificate for development purposes can be created as follows:

--- a/src/charm.py
+++ b/src/charm.py
@@ -145,7 +145,7 @@ class SupersetK8SCharm(CharmBase):
             self.unit.status = WaitingStatus("Waiting for peer relation.")
             return False
 
-        if not self._state.postgresql_relation == "enabled":
+        if not self._state.postgresql_relation:
             self.unit.status = BlockedStatus("Needs a PostgreSQL relation")
             return False
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -216,7 +216,6 @@ class SupersetK8SCharm(CharmBase):
             return
 
         if not self.ready_to_start():
-            event.defer()
             return
 
         try:

--- a/src/relations/postgresql.py
+++ b/src/relations/postgresql.py
@@ -31,8 +31,8 @@ class Database(framework.Object):
             charm.postgresql_db.on.endpoints_changed, self._on_database_changed
         )
         self.framework.observe(
-            charm.on.postgresql_db_relation_departed,
-            self._on_database_relation_departed,
+            charm.on.postgresql_db_relation_broken,
+            self._on_database_relation_broken,
         )
 
     @log_event_handler(logger)
@@ -43,6 +43,9 @@ class Database(framework.Object):
             event: The event triggered when the relation changed.
         """
         if not self.charm.unit.is_leader():
+            return
+
+        if not event.endpoints:
             return
 
         host, port = event.endpoints.split(",", 1)[0].split(":")
@@ -59,8 +62,8 @@ class Database(framework.Object):
         self.charm._update(event)
 
     @log_event_handler(logger)
-    def _on_database_relation_departed(self, event):
-        """Handle database departed event.
+    def _on_database_relation_broken(self, event):
+        """Handle database broken event.
 
         Args:
             event: The event triggered when the relation departs.
@@ -74,6 +77,6 @@ class Database(framework.Object):
             return
 
         self.charm._state.sql_alchemy_uri = None
-        self.charm._state.postgresql_relation = "disabled"
+        self.charm._state.postgresql_relation = False
 
         self.charm._update(event)


### PR DESCRIPTION
Makes improvements to the postgresql relation: 

- Adds documentation to `README.me` and `CONTRIBUTING.md`
- Updates `departed` to `broken` handler. Both `departed` and `broken` events are emitted when a relation is terminated. `departed` allows for publishing of data to the relation data store and is emitted multiple times, `broken` is emitted once on termination. As no relation data is required to be updated, `broken` is preferred to avoid duplicated running of method. 
- Replaces "enabled/disabled" with bool for existence of the relation.
- Removes the `defer.event()` if one or more of the relations have not been established. This is to avoid the edge case when relation_broken events being deferred and running when both relations have been re-established.
- Added return on `if not event.endpoints` as both `broken` and `changed` events are emitted on relation terminated. This causes the `_on_database_changed` method to access endpoints that no longer exist. This PR prevents this method running if there are no endpoints.