### PR TITLE
CSS-5118 Active status verification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,10 @@ juju status
 juju debug-log
 ```
 ### Configure juju
+This is an optional step intended to make the update-status hook more responsive. The default value is 5m.
+Following deployment, the status of the application will be checked at this regular interval. By setting this to 1m the deployment will be able to reach an `Active` status soon after application start. Leaving this at 5m will require waiting 5 minutes following deployment for application verification.
+
+Be aware if you update this configuration on the model it will apply to all charms on that model.
 ```
 # customise update status hook interval:
 juju model-config update-status-hook-interval=1m

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,11 @@ juju model-config logging-config="<root>=INFO;unit=DEBUG"
 juju status
 juju debug-log
 ```
+### Configure juju
+```
+# customise update status hook interval:
+juju model-config update-status-hook-interval=1m
+```
 ### Deploy charm
 ```
 # Pack the charm:
@@ -69,6 +74,7 @@ charmcraft pack
 
 # Deploy the charm:
 juju deploy ./superset-k8s_ubuntu-22.04-amd64.charm --resource superset-image=apache/superset:2.1.0
+
 # Check deployment was successful:
 juju status
 ```

--- a/src/charm.py
+++ b/src/charm.py
@@ -143,7 +143,7 @@ class SupersetK8SCharm(CharmBase):
 
         if self.config["charm-function"] in ui_functions:
             if check.status != CheckStatus.UP:
-                self.unit.status = WaitingStatus()
+                self.unit.status = MaintenanceStatus()
                 return
 
         self.unit.status = ActiveStatus()

--- a/src/charm.py
+++ b/src/charm.py
@@ -143,10 +143,10 @@ class SupersetK8SCharm(CharmBase):
 
         if self.config["charm-function"] in ui_functions:
             if check.status != CheckStatus.UP:
-                self.unit.status = MaintenanceStatus()
+                self.unit.status = MaintenanceStatus("Status check: DOWN")
                 return
 
-        self.unit.status = ActiveStatus()
+        self.unit.status = ActiveStatus("Status check: UP")
 
     def _restart_application(self, container):
         """Restart application.
@@ -156,7 +156,6 @@ class SupersetK8SCharm(CharmBase):
         """
         self.unit.status = MaintenanceStatus(f"restarting {APP_NAME}")
         container.restart(self.name)
-        self._on_update_status()
 
     def ready_to_start(self):
         """Check if peer relation is established.
@@ -275,7 +274,7 @@ class SupersetK8SCharm(CharmBase):
         }
         container.add_layer(self.name, pebble_layer, combine=True)
         container.replan()
-        self.unit.status = WaitingStatus()
+        self.unit.status = MaintenanceStatus("replanning application")
 
 
 if __name__ == "__main__":

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,7 +4,6 @@
 """Charm integration test config."""
 
 import logging
-import time
 
 import pytest
 import pytest_asyncio

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -58,7 +58,6 @@ async def deploy(ops_test: OpsTest):
         )
 
         await perform_superset_integrations(ops_test)
-        time.sleep(30)  # wait for application to start
 
         await ops_test.model.wait_for_idle(
             apps=[NGINX_NAME, APP_NAME],

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -35,5 +35,5 @@ class TestDeployment:
         await restart_application(ops_test)
         assert (
             ops_test.model.applications[APP_NAME].units[0].workload_status
-            == "active"
+            == "maintenance"
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -109,8 +109,11 @@ class TestCharm(TestCase):
         )
         self.assertTrue(service.is_running())
 
-        # The WaitingStatus is set with no message.
-        self.assertEqual(harness.model.unit.status, WaitingStatus())
+        # The MaintenanceStatus is set with replan message.
+        self.assertEqual(
+            harness.model.unit.status,
+            MaintenanceStatus("replanning application"),
+        )
 
     def test_invalid_config_value(self):
         """The charm blocks if an invalid config value is provided."""
@@ -167,8 +170,11 @@ class TestCharm(TestCase):
         ] = "example-pass"  # nosec
         self.assertEqual(got_plan, want_plan)
 
-        # The WaitingStatus is set with no message.
-        self.assertEqual(harness.model.unit.status, WaitingStatus())
+        # The MaintenanceStatus is set with replan message.
+        self.assertEqual(
+            harness.model.unit.status,
+            MaintenanceStatus("replanning application"),
+        )
 
     def test_ingress(self):
         """The charm relates correctly to the nginx ingress charm."""
@@ -203,7 +209,9 @@ class TestCharm(TestCase):
         container.get_check.return_value.status = CheckStatus.UP
         harness.charm.on.update_status.emit()
 
-        self.assertEqual(harness.model.unit.status, ActiveStatus())
+        self.assertEqual(
+            harness.model.unit.status, ActiveStatus("Status check: UP")
+        )
 
     def test_update_status_down(self):
         """The charm updates the unit status to maintenance based on DOWN status."""
@@ -216,7 +224,9 @@ class TestCharm(TestCase):
         container.get_check.return_value.status = CheckStatus.DOWN
         harness.charm.on.update_status.emit()
 
-        self.assertEqual(harness.model.unit.status, MaintenanceStatus())
+        self.assertEqual(
+            harness.model.unit.status, MaintenanceStatus("Status check: DOWN")
+        )
 
 
 @mock.patch("charm.Redis._get_redis_relation_data")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -12,7 +12,12 @@ import json
 import logging
 from unittest import TestCase, mock
 
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.model import (
+    ActiveStatus,
+    BlockedStatus,
+    MaintenanceStatus,
+    WaitingStatus,
+)
 from ops.pebble import CheckStatus
 from ops.testing import Harness
 
@@ -201,7 +206,7 @@ class TestCharm(TestCase):
         self.assertEqual(harness.model.unit.status, ActiveStatus())
 
     def test_update_status_down(self):
-        """The charm updates the unit status to waiting based on DOWN status."""
+        """The charm updates the unit status to maintenance based on DOWN status."""
         harness = self.harness
 
         simulate_lifecycle(harness)
@@ -211,7 +216,7 @@ class TestCharm(TestCase):
         container.get_check.return_value.status = CheckStatus.DOWN
         harness.charm.on.update_status.emit()
 
-        self.assertEqual(harness.model.unit.status, WaitingStatus())
+        self.assertEqual(harness.model.unit.status, MaintenanceStatus())
 
 
 @mock.patch("charm.Redis._get_redis_relation_data")


### PR DESCRIPTION
The `ActiveStatus` was previously being set immediately following pebble re-plan. This was misleading as the application has not been verified to be running before setting this status. This PR utilises [checks](https://juju.is/docs/sdk/interact-with-pebble#heading--check-configuration) to set the status as either Maintenance (unverified or unsuccessful verification) or Active (successful verification). 

A few notes:
- verification is via access to the web server hence this only applies when the superset charm has been configured with `app` or `gunicorn app` functions. Additional verification will be put in place for other functions with future PRs.
- The `update_status` hook is by default run every 5 minutes. In order to speed up the process of verification the `juju model-config` should be updated for this to run every minute. Otherwise the application cannot be marked as active for a minimum of 5 minutes. 
- on check failure being marked as `ignore` as opposed to `restart` is due to the fact that the application will show `CheckStatus.DOWN` while starting up the web server as this can take some time. And we do not want the application to restart due to this.