### PR TITLE
CSS-5081 Add beat and worker functions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,8 +76,14 @@ juju model-config update-status-hook-interval=1m
 # Pack the charm:
 charmcraft pack
 
-# Deploy the charm:
-juju deploy ./superset-k8s_ubuntu-22.04-amd64.charm --resource superset-image=apache/superset:2.1.0
+# deploy the web server
+juju deploy ./superset-k8s_ubuntu-22.04-amd64.charm --resource superset-image=apache/superset:2.1.0 superset-k8s-ui
+
+# deploy a worker
+juju deploy ./superset-k8s_ubuntu-22.04-amd64.charm --resource superset-image=apache/superset:2.1.0 --config charm-function=worker superset-k8s-worker
+
+# deploy the beat scheduler
+juju deploy ./superset-k8s_ubuntu-22.04-amd64.charm --resource superset-image=apache/superset:2.1.0 --config charm-function=beat superset-k8s-beat
 
 # Check deployment was successful:
 juju status
@@ -120,5 +126,5 @@ This relation makes use of the `data_platform_libs.v0.data_interfaces` library. 
 ## Cleanup
 # Remove the application before retrying
 ```
-juju remove-application superset-k8s --force
+juju remove-application superset-k8s-ui superset-k8s-beat superset-k8s-worker --force
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 # superset-k8s-charm
 Superset is fast, lightweight, intuitive, and loaded with options that make it easy for users of all skill sets to explore and visualize their data.
 
+## Superset UI, worker and beat deployment
+The same Superset charm can act as either a web server, worker or beat-scheduler. This is determined by the configuration parameter `charm-function`, which can be any of `app-gunicorn` (web), `app` (web development), `worker` or `beat`. Each Superset application must be related to the same PostgreSQL and Redis clusters for communication. The default value of `charm-function` is `app-gunicorn`.
+
+```
+# pack the charm
+charmcraft pack
+
+# deploy the web server
+juju deploy ./superset-k8s_ubuntu-22.04-amd64.charm --resource superset-image=apache/superset:2.1.0 superset-k8s-ui
+
+# deploy a worker
+juju deploy ./superset-k8s_ubuntu-22.04-amd64.charm --resource superset-image=apache/superset:2.1.0 --config charm-function=worker superset-k8s-worker
+
+# deploy the beat scheduler
+juju deploy ./superset-k8s_ubuntu-22.04-amd64.charm --resource superset-image=apache/superset:2.1.0 --config charm-function=beat superset-k8s-beat
+```
+Note: while there can be multiple workers or web servers, there should only every be 1 Superset beat deployment.
+
+
 ## Relations
 ### Redis
 Redis acts as both a cache and message broker for Superset services. It's a requirement to have a redis relation in order to start the Superset application.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ juju deploy ./superset-k8s_ubuntu-22.04-amd64.charm --resource superset-image=ap
 # deploy the beat scheduler
 juju deploy ./superset-k8s_ubuntu-22.04-amd64.charm --resource superset-image=apache/superset:2.1.0 --config charm-function=beat superset-k8s-beat
 ```
-Note: while there can be multiple workers or web servers, there should only every be 1 Superset beat deployment.
+Note: while there can be multiple workers or web servers, there should only ever be 1 Superset beat deployment.
 
 
 ## Relations

--- a/src/charm.py
+++ b/src/charm.py
@@ -26,12 +26,12 @@ from ops.model import (
 )
 from ops.pebble import CheckStatus
 
-from literals import APP_NAME, APPLICATION_PORT, INIT_USERS
+from literals import APP_NAME, APPLICATION_PORT
 from log import log_event_handler
 from relations.postgresql import Database
 from relations.redis import Redis
 from state import State
-from utils import generate_password, load_superset_files, generate_random_string
+from utils import generate_random_string, load_superset_files
 
 # Log messages can be retrieved using juju debug-log
 logger = logging.getLogger(__name__)
@@ -212,9 +212,9 @@ class SupersetK8SCharm(CharmBase):
         Returns:
             env: dictionary of environment variables
         """
-        superset_secret = (
-            self.config.get("superset-secret-key") or generate_password()
-        )
+        superset_secret = self.config.get(
+            "superset-secret-key"
+        ) or generate_random_string(32)
         charm_function = self.config["charm-function"]
         random_id = generate_random_string(5)
         env = {
@@ -224,7 +224,7 @@ class SupersetK8SCharm(CharmBase):
             "SQL_ALCHEMY_URI": self._state.sql_alchemy_uri,
             "REDIS_HOST": self._state.redis_host,
             "REDIS_PORT": self._state.redis_port,
-            "ADMIN_USER": f"{charm_function}-{random_id}"
+            "ADMIN_USER": f"{charm_function}-{random_id}",
         }
         return env
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -26,12 +26,12 @@ from ops.model import (
 )
 from ops.pebble import CheckStatus
 
-from literals import APP_NAME, APPLICATION_PORT
+from literals import APP_NAME, APPLICATION_PORT, INIT_USERS
 from log import log_event_handler
 from relations.postgresql import Database
 from relations.redis import Redis
 from state import State
-from utils import generate_password, load_superset_files
+from utils import generate_password, load_superset_files, generate_random_string
 
 # Log messages can be retrieved using juju debug-log
 logger = logging.getLogger(__name__)
@@ -139,9 +139,9 @@ class SupersetK8SCharm(CharmBase):
 
         container = self.unit.get_container(self.name)
         ui_functions = ["app", "app-gunicorn"]
-        check = container.get_check("up")
 
         if self.config["charm-function"] in ui_functions:
+            check = container.get_check("up")
             if check.status != CheckStatus.UP:
                 self.unit.status = MaintenanceStatus("Status check: DOWN")
                 return
@@ -212,17 +212,19 @@ class SupersetK8SCharm(CharmBase):
         Returns:
             env: dictionary of environment variables
         """
-        self._state.superset_secret = (
+        superset_secret = (
             self.config.get("superset-secret-key") or generate_password()
         )
-        self._state.admin_password = self.config["admin-password"]
+        charm_function = self.config["charm-function"]
+        random_id = generate_random_string(5)
         env = {
-            "SUPERSET_SECRET_KEY": self._state.superset_secret,
-            "ADMIN_PASSWORD": self._state.admin_password,
-            "CHARM_FUNCTION": self.config["charm-function"],
+            "SUPERSET_SECRET_KEY": superset_secret,
+            "ADMIN_PASSWORD": self.config["admin-password"],
+            "CHARM_FUNCTION": charm_function,
             "SQL_ALCHEMY_URI": self._state.sql_alchemy_uri,
             "REDIS_HOST": self._state.redis_host,
             "REDIS_PORT": self._state.redis_port,
+            "ADMIN_USER": f"{charm_function}-{random_id}"
         }
         return env
 
@@ -264,14 +266,19 @@ class SupersetK8SCharm(CharmBase):
                     "on-check-failure": {"up": "ignore"},
                 }
             },
-            "checks": {
-                "up": {
-                    "override": "replace",
-                    "period": "10s",
-                    "http": {"url": "http://localhost:8088/"},
-                }
-            },
         }
+        if self.config["charm-function"] in ["app", "app-gunicorn"]:
+            pebble_layer.update(
+                {
+                    "checks": {
+                        "up": {
+                            "override": "replace",
+                            "period": "10s",
+                            "http": {"url": "http://localhost:8088/"},
+                        }
+                    }
+                },
+            )
         container.add_layer(self.name, pebble_layer, combine=True)
         container.replan()
         self.unit.status = MaintenanceStatus("replanning application")

--- a/src/charm.py
+++ b/src/charm.py
@@ -26,7 +26,12 @@ from ops.model import (
 )
 from ops.pebble import CheckStatus
 
-from literals import APP_NAME, APPLICATION_PORT
+from literals import (
+    APP_NAME,
+    APPLICATION_PORT,
+    UI_FUNCTIONS,
+    VALID_CHARM_FUNCTIONS,
+)
 from log import log_event_handler
 from relations.postgresql import Database
 from relations.redis import Redis
@@ -138,9 +143,8 @@ class SupersetK8SCharm(CharmBase):
             return
 
         container = self.unit.get_container(self.name)
-        ui_functions = ["app", "app-gunicorn"]
 
-        if self.config["charm-function"] in ui_functions:
+        if self.config["charm-function"] in UI_FUNCTIONS:
             check = container.get_check("up")
             if check.status != CheckStatus.UP:
                 self.unit.status = MaintenanceStatus("Status check: DOWN")
@@ -199,9 +203,8 @@ class SupersetK8SCharm(CharmBase):
         Raises:
             ValueError: in case when invalid charm-funcion is entered
         """
-        valid_charm_functions = ["app-gunicorn", "app", "worker", "beat"]
         charm_function = self.model.config["charm-function"]
-        if charm_function not in valid_charm_functions:
+        if charm_function not in VALID_CHARM_FUNCTIONS:
             raise ValueError(
                 f"config: invalid charm function {charm_function!r}"
             )
@@ -267,7 +270,7 @@ class SupersetK8SCharm(CharmBase):
                 }
             },
         }
-        if self.config["charm-function"] in ["app", "app-gunicorn"]:
+        if self.config["charm-function"] in UI_FUNCTIONS:
             pebble_layer.update(
                 {
                     "checks": {

--- a/src/literals.py
+++ b/src/literals.py
@@ -15,3 +15,9 @@ INIT_FILES = [
     "requirements-local.txt",
     "superset_config.py",
 ]
+INIT_USERS = {
+    "app-gunicorn": "admin",
+    "app": "admin",
+    "worker": "worker",
+    "beat": "beat",
+}

--- a/src/literals.py
+++ b/src/literals.py
@@ -15,9 +15,3 @@ INIT_FILES = [
     "requirements-local.txt",
     "superset_config.py",
 ]
-INIT_USERS = {
-    "app-gunicorn": "admin",
-    "app": "admin",
-    "worker": "worker",
-    "beat": "beat",
-}

--- a/src/literals.py
+++ b/src/literals.py
@@ -15,3 +15,5 @@ INIT_FILES = [
     "requirements-local.txt",
     "superset_config.py",
 ]
+UI_FUNCTIONS = ["app", "app-gunicorn"]
+VALID_CHARM_FUNCTIONS = ["app-gunicorn", "app", "worker", "beat"]

--- a/src/utils.py
+++ b/src/utils.py
@@ -8,7 +8,6 @@ import logging
 import os
 import secrets
 import string
-import random
 
 from literals import CONFIG_FILE, CONFIG_PATH, INIT_FILES, INIT_PATH
 
@@ -31,16 +30,19 @@ def charm_path(file_path):
     return path
 
 
-def generate_password() -> str:
-    """Create randomized string for use as app passwords.
+def generate_random_string(length) -> str:
+    """Create randomized string for use as app passwords and username ID.
+
+    Args:
+        length: number of characters to generate
 
     Returns:
-        String of 32 randomized letter+digit characters
+        String of randomized letter+digit characters
     """
     return "".join(
         [
             secrets.choice(string.ascii_letters + string.digits)
-            for _ in range(32)
+            for _ in range(length)
         ]
     )
 
@@ -74,15 +76,3 @@ def load_superset_files(container):
         else:
             path = INIT_PATH
         push_files(container, f"templates/{file}", f"{path}/{file}", 0o744)
-
-def generate_random_string(length):
-    """Generate random string of numbers and letters.
-
-    Args:
-        length: length of the string generated
-
-    Returns:
-        random_string: random string of numbers and letters"""
-    characters = string.ascii_letters + string.digits
-    random_string = ''.join(random.choice(characters) for _ in range(length))
-    return random_string

--- a/src/utils.py
+++ b/src/utils.py
@@ -8,6 +8,7 @@ import logging
 import os
 import secrets
 import string
+import random
 
 from literals import CONFIG_FILE, CONFIG_PATH, INIT_FILES, INIT_PATH
 
@@ -73,3 +74,15 @@ def load_superset_files(container):
         else:
             path = INIT_PATH
         push_files(container, f"templates/{file}", f"{path}/{file}", 0o744)
+
+def generate_random_string(length):
+    """Generate random string of numbers and letters.
+
+    Args:
+        length: length of the string generated
+
+    Returns:
+        random_string: random string of numbers and letters"""
+    characters = string.ascii_letters + string.digits
+    random_string = ''.join(random.choice(characters) for _ in range(length))
+    return random_string

--- a/templates/k8s-bootstrap.sh
+++ b/templates/k8s-bootstrap.sh
@@ -41,7 +41,7 @@ echo "Initialising superset"
 
 if [[ "${CHARM_FUNCTION}" == "worker" ]]; then
   echo "Starting Celery worker..."
-  celery --app=superset.tasks.celery_app:app worker -O fair -l INFO
+  celery --app=superset.tasks.celery_app:app worker -O fair -l INFO --uid 1
 elif [[ "${CHARM_FUNCTION}" == "beat" ]]; then
   echo "Starting Celery beat..."
   celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule

--- a/templates/k8s-init.sh
+++ b/templates/k8s-init.sh
@@ -43,9 +43,9 @@ superset db upgrade
 echo_step "1" "Complete" "Applying DB migrations"
 
 # Create an admin user
-echo_step "2" "Starting" "Setting up admin user ( admin / $ADMIN_PASSWORD )"
+echo_step "2" "Starting" "Setting up admin user ( $ADMIN_USER / $ADMIN_PASSWORD )"
 superset fab create-admin \
-              --username admin \
+              --username $ADMIN_USER \
               --firstname Superset \
               --lastname Admin \
               --email admin@superset.com \

--- a/templates/k8s-init.sh
+++ b/templates/k8s-init.sh
@@ -45,11 +45,11 @@ echo_step "1" "Complete" "Applying DB migrations"
 # Create an admin user
 echo_step "2" "Starting" "Setting up admin user ( $ADMIN_USER / $ADMIN_PASSWORD )"
 superset fab create-admin \
-              --username $ADMIN_USER \
+              --username "$ADMIN_USER" \
               --firstname Superset \
               --lastname Admin \
               --email admin@superset.com \
-              --password $ADMIN_PASSWORD
+              --password "$ADMIN_PASSWORD"
 echo_step "2" "Complete" "Setting up admin user"
 # Create default roles and permissions
 echo_step "3" "Starting" "Setting up roles and perms"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -9,7 +9,7 @@ import logging
 import pytest
 import requests
 from conftest import deploy  # noqa: F401, pylint: disable=W0611
-from helpers import APP_NAME, get_unit_url, restart_application
+from helpers import UI_NAME, get_unit_url, restart_application
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ class TestDeployment:
     async def test_ui(self, ops_test: OpsTest):
         """Perform GET request on the Superset UI host."""
         url = await get_unit_url(
-            ops_test, application=APP_NAME, unit=0, port=8088
+            ops_test, application=UI_NAME, unit=0, port=8088
         )
         logger.info("curling app address: %s", url)
 
@@ -34,6 +34,6 @@ class TestDeployment:
         """Removes an existing connector confirms database removed."""
         await restart_application(ops_test)
         assert (
-            ops_test.model.applications[APP_NAME].units[0].workload_status
+            ops_test.model.applications[UI_NAME].units[0].workload_status
             == "maintenance"
         )


### PR DESCRIPTION
This PR adds the ability to deploy the superset application as a `worker` or `beat` by setting the `charm-function` configuration parameter accordingly. The PR:

- Updates `README.md` on how to deploy `worker` and `beat` applications 
- Makes the UI check specific to the web server deployment of superset
- updates the uid flag (default 0) so that the worker does not have superuser privileges
- Makes the  `ADMIN_USER` an environment variable to support multiple deployments of the application with different usernames matching the function that application will provide.
- Adds a Talisman configuration: https://superset.apache.org/docs/security/#content-security-policy-csp
- Adds reasonable configuration in terms of `beat_schedule` and `FEATURE_FLAGS`
Note, in future PRs the `beat_schedule` and/or `FEATURE_FLAGS` may be updated as config parameters.