### PR TITLE
CSS-4886 Google oauth added to Superset charm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,15 +95,10 @@ To validate Google Oauth authentication:
 # Port forward the web server
 kubectl port-forward pod/superset-k8s-0 8088:8088 -n superset-k8s
 
-# Edit /etc/hosts
-sudo vim /etc/hosts
-
-# Add a mapping as follows
-127.0.0.1 superset.com
-
 ```
-You can then update the Google `redirect_uri` to  `http://superset.com:8088/oauth-authorized/google`.
+You can then update the Google `redirect_uri` to  `http://localhost:8088/oauth-authorized/google`.
 
+Please note: `redirect_uri` should be updated to `https://<host>/oauth-authorized/google` when deploying to production.
 
 Once you have authenticated with Google, to verify the user credentials that have been created you can access these through the PostgreSQL charm as follows:
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,45 @@ juju deploy ./superset-k8s_ubuntu-22.04-amd64.charm --resource superset-image=ap
 # Check deployment was successful:
 juju status
 ```
+
+### Authentication
+To validate Google Oauth authentication:
+```
+# Port forward the web server
+kubectl port-forward pod/superset-k8s-0 8088:8088
+
+# Edit /etc/hosts
+sudo vim /etc/hosts
+
+# Add a mapping as follows
+127.0.0.1 superset.com
+
+```
+You can then update the Google `redirect_uri` to  `http://superset.com:8088/oauth-authorized/google`.
+
+
+Once you have authenticated with Google, to verify the user credentials that have been created you can access these through the PostgreSQL charm as follows:
+```
+# Get the postgresql password
+juju run postgresql-k8s/leader get-password
+
+# Make note of the postgresql unit IP
+juju status
+
+# SSH into the application
+juju ssh --container postgresql postgresql-k8s/leader bash
+
+# Use psql as the postgres user
+psql --host=<unit ip> --username=operator --password postgres
+
+# Connect to the superset database
+\c superset
+
+# Verify the credentials created for your user
+SELECT * FROM ab_user WHERE email = '<your email>';
+
+```
+
 ## Relations
 ### Redis
 Redis acts as both a cache and message broker for Superset services. It's a requirement to have a redis relation in order to start the Superset application.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ juju status
 To validate Google Oauth authentication:
 ```
 # Port forward the web server
-kubectl port-forward pod/superset-k8s-0 8088:8088
+kubectl port-forward pod/superset-k8s-0 8088:8088 -n superset-k8s
 
 # Edit /etc/hosts
 sudo vim /etc/hosts

--- a/README.md
+++ b/README.md
@@ -19,6 +19,45 @@ juju deploy ./superset-k8s_ubuntu-22.04-amd64.charm --resource superset-image=ap
 ```
 Note: while there can be multiple workers or web servers, there should only ever be 1 Superset beat deployment.
 
+## Authentication
+Username/password authentication is enabled by default using the `admin` user and the password set via the Superset configuration value `admin-password`.
+
+To enable Google Oauth, you will need a Google project, you can create one [here](https://console.cloud.google.com/projectcreate).
+
+### Obtain Oauth2 credentials
+If you do not already have Oauth2 credentials set up then follow the steps below:
+1. Navigate to https://console.cloud.google.com/apis/credentials 
+2. Click `+ Create Credentials` 
+3. Select `Oauth client ID`
+4. Select application type (Web application)
+5. Name the application
+6. Add an Authorized redirect URI (`https://<host>:8088/oauth-authorized/google`)
+7. Create and download your client ID and client secret
+
+## Apply oauth configuration to Superset charm
+Create a file `oauth.yaml` using the Oauth2 credentials you obtained from Google, as follows:
+```
+superset-k8s:
+  google-client-id: "Your client id here"
+  google-client-secret: "Your client secret here"
+  oauth-domain: "yourcompanydomain.com"
+  oauth-admin-email: "youruser@yourcompany.com"
+
+```
+If you have given your charm deployment an alias this will replace `superset-k8s` in this file.
+
+Note: please ensure that the email provided by `oauth-admin-email` is one you can authenticate with Google, as this will be your `Admin` account. Additionally ensure that this email domain matches the `oauth-domain` provided.
+
+Apply these credentials to the Superset charm:
+```
+juju config superset-k8s --file=path/to/oauth.yaml
+```
+
+### Self-registration and roles
+By default, with Google Oauth, a Superset user account is automatically created following successful authentication. This user is provided the least privileged role of `Public`, this role can then be elevated in the UI or via API by an `Admin` user. 
+
+To change the role that is applied on self-registration, simply pass the role via the configuration parameter `self-registration-role`. Superset's standard roles and their associated permissions can be found [here](https://github.com/apache/superset/blob/master/RESOURCES/STANDARD_ROLES.md).
+
 
 ## Relations
 ### Redis

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ superset-k8s:
   google-client-id: "Your client id here"
   google-client-secret: "Your client secret here"
   oauth-domain: "yourcompanydomain.com"
-  oauth-admin-email: "youruser@yourcompany.com"
+  oauth-admin-email: "youruser@yourcompanydomain.com"
 
 ```
 If you have given your charm deployment an alias this will replace `superset-k8s` in this file.

--- a/config.yaml
+++ b/config.yaml
@@ -110,7 +110,7 @@ options:
     type: string
   oauth-domain:
     description: |
-      The domain for which to allow google authentication ie. canonical.com
+      The domain for which to allow Google authentication i.e. canonical.com
     type: string
   oauth-admin-email:
     description: |

--- a/config.yaml
+++ b/config.yaml
@@ -108,7 +108,15 @@ options:
     description: |
       Client password from Google Oauth setup
     type: string
-  auth-domain:
+  oauth-domain:
     description: |
       The domain for which to allow google authentication ie. canonical.com
     type: string
+  oauth-admin-email:
+    description: |
+      Email(s) to be given an Admin role on initialization.
+      This should either be a single email or multiple comma seperated emails
+      eg. example.email@company.com, example.email2@company.com
+      Required for Oauth.
+    type: string
+    default: admin@superset.com

--- a/config.yaml
+++ b/config.yaml
@@ -115,8 +115,13 @@ options:
   oauth-admin-email:
     description: |
       Email(s) to be given an Admin role on initialization.
-      This should either be a single email or multiple comma seperated emails
-      eg. example.email@company.com, example.email2@company.com
-      Required for Oauth.
+      Either a single email or a comma separated list.
+      eg. "example.email@company.com, example.email2@company.com"
     type: string
     default: admin@superset.com
+  self-registration-role:
+    description: |
+      The default role to be provided to users that self-register via Oauth.
+      One of `Admin`, `Alpha`, `Gamma`, `Public`, `sql_lab`
+    type: string
+    default: Public

--- a/config.yaml
+++ b/config.yaml
@@ -100,3 +100,15 @@ options:
         beyond the pool size when the pool is exhausted.
     default: 10
     type: int
+  google-client-id:
+    description: |
+      Client id from Google Oauth setup
+    type: string
+  google-client-secret:
+    description: |
+      Client password from Google Oauth setup
+    type: string
+  auth-domain:
+    description: |
+      The domain for which to allow google authentication ie. canonical.com
+    type: string

--- a/src/charm.py
+++ b/src/charm.py
@@ -241,9 +241,9 @@ class SupersetK8SCharm(CharmBase):
             "SQLALCHEMY_POOL_SIZE": self.config["sqlalchemy-pool-size"],
             "SQLALCHEMY_POOL_TIMEOUT": self.config["sqlalchemy-pool-timeout"],
             "SQLALCHEMY_MAX_OVERFLOW": self.config["sqlalchemy-max-overflow"],
-            "GOOGLE_KEY": self.config["google-client-id"],
-            "GOOGLE_SECRET": self.config["google-client-secret"],
-            "AUTH_DOMAIN": self.config["auth-domain"],
+            "GOOGLE_KEY": self.config.get("google-client-id"),
+            "GOOGLE_SECRET": self.config.get("google-client-secret"),
+            "AUTH_DOMAIN": self.config.get("auth-domain"),
         }
         return env
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -101,7 +101,7 @@ class SupersetK8SCharm(CharmBase):
             service_name=self.app.name,
             service_port=APPLICATION_PORT,
             tls_secret_name=self.config["tls-secret-name"],
-            backend_protocol="HTTPS",
+            backend_protocol="HTTP",
         )
 
     @log_event_handler(logger)
@@ -219,7 +219,7 @@ class SupersetK8SCharm(CharmBase):
             "superset-secret-key"
         ) or generate_random_string(32)
         charm_function = self.config["charm-function"]
-        random_id = generate_random_string(5)
+        admin_email = self.config["oauth-admin-email"]
         env = {
             "SUPERSET_SECRET_KEY": superset_secret,
             "ADMIN_PASSWORD": self.config["admin-password"],
@@ -227,7 +227,6 @@ class SupersetK8SCharm(CharmBase):
             "SQL_ALCHEMY_URI": self._state.sql_alchemy_uri,
             "REDIS_HOST": self._state.redis_host,
             "REDIS_PORT": self._state.redis_port,
-            "ADMIN_USER": f"{charm_function}-{random_id}",
             "ALERTS_ATTACH_REPORTS": self.config["alerts-attach-reports"],
             "DASHBOARD_CROSS_FILTERS": self.config["dashboard-cross-filters"],
             "DASHBOARD_RBAC": self.config["dashboard-rbac"],
@@ -243,7 +242,8 @@ class SupersetK8SCharm(CharmBase):
             "SQLALCHEMY_MAX_OVERFLOW": self.config["sqlalchemy-max-overflow"],
             "GOOGLE_KEY": self.config.get("google-client-id"),
             "GOOGLE_SECRET": self.config.get("google-client-secret"),
-            "AUTH_DOMAIN": self.config.get("auth-domain"),
+            "OAUTH_DOMAIN": self.config.get("oauth-domain"),
+            "OAUTH_ADMIN_EMAIL": admin_email,
         }
         return env
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -241,6 +241,9 @@ class SupersetK8SCharm(CharmBase):
             "SQLALCHEMY_POOL_SIZE": self.config["sqlalchemy-pool-size"],
             "SQLALCHEMY_POOL_TIMEOUT": self.config["sqlalchemy-pool-timeout"],
             "SQLALCHEMY_MAX_OVERFLOW": self.config["sqlalchemy-max-overflow"],
+            "GOOGLE_KEY": self.config["google-client-id"],
+            "GOOGLE_SECRET": self.config["google-client-secret"],
+            "AUTH_DOMAIN": self.config["auth-domain"],
         }
         return env
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -31,6 +31,7 @@ from literals import (
     APPLICATION_PORT,
     UI_FUNCTIONS,
     VALID_CHARM_FUNCTIONS,
+    VALID_ROLES,
 )
 from log import log_event_handler
 from relations.postgresql import Database
@@ -208,6 +209,11 @@ class SupersetK8SCharm(CharmBase):
             raise ValueError(
                 f"config: invalid charm function {charm_function!r}"
             )
+        default_role = self.config["self-registration-role"]
+        if default_role not in VALID_ROLES:
+            raise ValueError(
+                f"config: invalid self-registration role {default_role!r}"
+            )
 
     def _create_env(self):
         """Create state values from config to be used as environment variables.
@@ -244,6 +250,7 @@ class SupersetK8SCharm(CharmBase):
             "GOOGLE_SECRET": self.config.get("google-client-secret"),
             "OAUTH_DOMAIN": self.config.get("oauth-domain"),
             "OAUTH_ADMIN_EMAIL": admin_email,
+            "SELF_REGISTRATION_ROLE": self.config["self-registration-role"],
         }
         return env
 

--- a/src/literals.py
+++ b/src/literals.py
@@ -18,3 +18,4 @@ INIT_FILES = [
 ]
 UI_FUNCTIONS = ["app", "app-gunicorn"]
 VALID_CHARM_FUNCTIONS = ["app-gunicorn", "app", "worker", "beat"]
+VALID_ROLES = ["Admin", "Alpha", "Gamma", "Public", "sql_lab"]

--- a/src/literals.py
+++ b/src/literals.py
@@ -6,7 +6,7 @@
 
 APPLICATION_PORT = 8088
 APP_NAME = "superset"
-CONFIG_FILE = "superset_config.py"
+CONFIG_FILES = ["superset_config.py", "custom_sso_security_manager.py"]
 CONFIG_PATH = "/app/pythonpath"
 INIT_PATH = "/app/k8s"
 INIT_FILES = [
@@ -14,6 +14,7 @@ INIT_FILES = [
     "k8s-init.sh",
     "requirements-local.txt",
     "superset_config.py",
+    "custom_sso_security_manager.py",
 ]
 UI_FUNCTIONS = ["app", "app-gunicorn"]
 VALID_CHARM_FUNCTIONS = ["app-gunicorn", "app", "worker", "beat"]

--- a/src/utils.py
+++ b/src/utils.py
@@ -9,7 +9,7 @@ import os
 import secrets
 import string
 
-from literals import CONFIG_FILE, CONFIG_PATH, INIT_FILES, INIT_PATH
+from literals import CONFIG_FILES, CONFIG_PATH, INIT_FILES, INIT_PATH
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +71,7 @@ def load_superset_files(container):
         container: the application container
     """
     for file in INIT_FILES:
-        if file == CONFIG_FILE:
+        if file in CONFIG_FILES:
             path = CONFIG_PATH
         else:
             path = INIT_PATH

--- a/templates/custom_sso_security_manager.py
+++ b/templates/custom_sso_security_manager.py
@@ -1,0 +1,9 @@
+from superset.security import SupersetSecurityManager
+
+class CustomSsoSecurityManager(SupersetSecurityManager):
+
+    def oauth_user_info(self, provider, response=None):
+        if provider == 'google':
+            me = self.appbuilder.sm.oauth_remotes[provider].get('https://openidconnect.googleapis.com/v1/userinfo')
+            data = me.json()
+            return { 'name' : data['name'], 'email' : data['email'], 'id' : data['sub'], 'username' : data['email'], 'first_name': data['given_name'], 'last_name': data['family_name']}

--- a/templates/custom_sso_security_manager.py
+++ b/templates/custom_sso_security_manager.py
@@ -1,9 +1,18 @@
 from superset.security import SupersetSecurityManager
 
-class CustomSsoSecurityManager(SupersetSecurityManager):
 
+class CustomSsoSecurityManager(SupersetSecurityManager):
     def oauth_user_info(self, provider, response=None):
-        if provider == 'google':
-            me = self.appbuilder.sm.oauth_remotes[provider].get('https://openidconnect.googleapis.com/v1/userinfo')
+        if provider == "google":
+            me = self.appbuilder.sm.oauth_remotes[provider].get(
+                "https://openidconnect.googleapis.com/v1/userinfo"
+            )
             data = me.json()
-            return { 'name' : data['name'], 'email' : data['email'], 'id' : data['sub'], 'username' : data['email'], 'first_name': data['given_name'], 'last_name': data['family_name']}
+            return {
+                "name": data["name"],
+                "email": data["email"],
+                "id": data["sub"],
+                "username": data["email"],
+                "first_name": data["given_name"],
+                "last_name": data["family_name"],
+            }

--- a/templates/k8s-init.sh
+++ b/templates/k8s-init.sh
@@ -43,9 +43,9 @@ superset db upgrade
 echo_step "1" "Complete" "Applying DB migrations"
 
 # Create an admin user
-echo_step "2" "Starting" "Setting up admin user ( $ADMIN_USER / $ADMIN_PASSWORD )"
+echo_step "2" "Starting" "Setting up admin user ( admin / $ADMIN_PASSWORD )"
 superset fab create-admin \
-              --username "$ADMIN_USER" \
+              --username admin \
               --firstname Superset \
               --lastname Admin \
               --email admin@superset.com \

--- a/templates/superset_config.py
+++ b/templates/superset_config.py
@@ -2,6 +2,7 @@ import os
 from cachelib.redis import RedisCache
 from celery.schedules import crontab
 from flask_appbuilder.security.manager import AUTH_OAUTH
+from custom_sso_security_manager import CustomSsoSecurityManager
 
 # Redis caching
 CACHE_CONFIG = {
@@ -113,6 +114,7 @@ required_auth_vars = ["GOOGLE_KEY", "GOOGLE_SECRET", "OAUTH_DOMAIN"]
 
 if all(os.getenv(var) for var in required_auth_vars):
     AUTH_TYPE = AUTH_OAUTH
+    CUSTOM_SECURITY_MANAGER = CustomSsoSecurityManager
     OAUTH_PROVIDERS = [
             {
                 "name": "google",
@@ -129,7 +131,7 @@ if all(os.getenv(var) for var in required_auth_vars):
                     "authorize_params": {"hd": os.getenv("OAUTH_DOMAIN", "")},
                     "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
                 },
-            }
+            },
         ]
 
     # Will allow user self registration, allowing to create Flask users from Authorized User

--- a/templates/superset_config.py
+++ b/templates/superset_config.py
@@ -33,23 +33,9 @@ RESULTS_BACKEND = RedisCache(
     port=os.getenv("REDIS_PORT"),
     key_prefix="superset_results",
 )
-TALISMAN_ENABLED = True
-TALISMAN_CONFIG = {
-    "content_security_policy": {
-        "default-src": ["'self'"],
-        "img-src": ["'self'", "data:"],
-        "worker-src": ["'self'", "blob:"],
-        "connect-src": [
-            "'self'",
-            "https://api.mapbox.com",
-            "https://events.mapbox.com",
-        ],
-        "object-src": "'none'",
-        "style-src": ["'self'", "'unsafe-inline'"],
-        "script-src": ["'self'", "'unsafe-inline'"],
-    },
-    "force_https": False,
-}
+
+TALISMAN_ENABLED = False
+CONTENT_SECURITY_POLICY_WARNING = False
 
 SQLALCHEMY_POOL_SIZE = int(os.getenv('SQLALCHEMY_POOL_SIZE'))
 SQLALCHEMY_POOL_TIMEOUT = int(os.getenv('SQLALCHEMY_POOL_TIMEOUT'))
@@ -123,7 +109,7 @@ ENABLE_TIME_ROTATE = True
 SQLALCHEMY_DATABASE_URI = os.getenv("SQL_ALCHEMY_URI")
 
 #OAUTH configuration
-required_auth_vars = ["GOOGLE_KEY", "GOOGLE_SECRET", "AUTH_DOMAIN"]
+required_auth_vars = ["GOOGLE_KEY", "GOOGLE_SECRET", "OAUTH_DOMAIN"]
 
 if all(os.getenv(var) for var in required_auth_vars):
     AUTH_TYPE = AUTH_OAUTH
@@ -140,7 +126,7 @@ if all(os.getenv(var) for var in required_auth_vars):
                     "request_token_url": None,
                     "access_token_url": "https://accounts.google.com/o/oauth2/token",
                     "authorize_url": "https://accounts.google.com/o/oauth2/auth",
-                    "authorize_params": {"hd": os.getenv("AUTH_DOMAIN", "")}
+                    "authorize_params": {"hd": os.getenv("OAUTH_DOMAIN", "")}
                 },
             }
         ]
@@ -148,5 +134,9 @@ if all(os.getenv(var) for var in required_auth_vars):
     # Will allow user self registration, allowing to create Flask users from Authorized User
     AUTH_USER_REGISTRATION = True
 
-    # The default user self registration role
-    AUTH_USER_REGISTRATION_ROLE = "Public"
+    # The custom logic for user self registration role
+    admin_users = os.getenv("OAUTH_ADMIN_EMAIL")
+    AUTH_USER_REGISTRATION_ROLE_JMESPATH=f"contains(['{admin_users}'], email) && 'Admin' || 'Gamma'"
+
+    # For Google https redirect
+    ENABLE_PROXY_FIX = True

--- a/templates/superset_config.py
+++ b/templates/superset_config.py
@@ -125,7 +125,7 @@ SQLALCHEMY_DATABASE_URI = os.getenv("SQL_ALCHEMY_URI")
 #OAUTH configuration
 required_auth_vars = ["GOOGLE_KEY", "GOOGLE_SECRET", "AUTH_DOMAIN"]
 
-if all(os.getauth(var) for var in required_auth_vars):
+if all(os.getenv(var) for var in required_auth_vars):
     AUTH_TYPE = AUTH_OAUTH
     OAUTH_PROVIDERS = [
             {

--- a/templates/superset_config.py
+++ b/templates/superset_config.py
@@ -1,6 +1,7 @@
 import os
 from cachelib.redis import RedisCache
 from celery.schedules import crontab
+from flask_appbuilder.security.manager import AUTH_OAUTH
 
 # Redis caching
 CACHE_CONFIG = {
@@ -120,3 +121,32 @@ ENABLE_TIME_ROTATE = True
 
 # postgresql metadata db
 SQLALCHEMY_DATABASE_URI = os.getenv("SQL_ALCHEMY_URI")
+
+#OAUTH configuration
+required_auth_vars = ["GOOGLE_KEY", "GOOGLE_SECRET", "AUTH_DOMAIN"]
+
+if all(os.getauth(var) for var in required_auth_vars):
+    AUTH_TYPE = AUTH_OAUTH
+    OAUTH_PROVIDERS = [
+            {
+                "name": "google",
+                "icon": "fa-google",
+                "token_key": "access_token",
+                "remote_app": {
+                    "client_id": os.getenv("GOOGLE_KEY"),
+                    "client_secret": os.getenv("GOOGLE_SECRET"),
+                    "api_base_url": "https://www.googleapis.com/oauth2/v2/",
+                    "client_kwargs": {"scope": "email profile"},
+                    "request_token_url": None,
+                    "access_token_url": "https://accounts.google.com/o/oauth2/token",
+                    "authorize_url": "https://accounts.google.com/o/oauth2/auth",
+                    "authorize_params": {"hd": os.getenv("AUTH_DOMAIN", "")}
+                },
+            }
+        ]
+
+    # Will allow user self registration, allowing to create Flask users from Authorized User
+    AUTH_USER_REGISTRATION = True
+
+    # The default user self registration role
+    AUTH_USER_REGISTRATION_ROLE = "Public"

--- a/templates/superset_config.py
+++ b/templates/superset_config.py
@@ -38,17 +38,22 @@ RESULTS_BACKEND = RedisCache(
 TALISMAN_ENABLED = False
 CONTENT_SECURITY_POLICY_WARNING = False
 
-SQLALCHEMY_POOL_SIZE = int(os.getenv('SQLALCHEMY_POOL_SIZE'))
-SQLALCHEMY_POOL_TIMEOUT = int(os.getenv('SQLALCHEMY_POOL_TIMEOUT'))
-SQLALCHEMY_MAX_OVERFLOW = int(os.getenv('SQLALCHEMY_MAX_OVERFLOW'))
+SQLALCHEMY_POOL_SIZE = int(os.getenv("SQLALCHEMY_POOL_SIZE"))
+SQLALCHEMY_POOL_TIMEOUT = int(os.getenv("SQLALCHEMY_POOL_TIMEOUT"))
+SQLALCHEMY_MAX_OVERFLOW = int(os.getenv("SQLALCHEMY_MAX_OVERFLOW"))
+
 
 class CeleryConfig(object):
-    broker_url = f"redis://{os.getenv('REDIS_HOST')}:{os.getenv('REDIS_PORT')}/4"
+    broker_url = (
+        f"redis://{os.getenv('REDIS_HOST')}:{os.getenv('REDIS_PORT')}/4"
+    )
     imports = (
         "superset.sql_lab",
         "superset.tasks",
     )
-    result_backend = f"redis://{os.getenv('REDIS_HOST')}:{os.getenv('REDIS_PORT')}/5"
+    result_backend = (
+        f"redis://{os.getenv('REDIS_HOST')}:{os.getenv('REDIS_PORT')}/5"
+    )
     worker_log_level = "DEBUG"
     worker_prefetch_multiplier = 10
     task_acks_late = True
@@ -64,13 +69,13 @@ class CeleryConfig(object):
         },
     }
     beat_schedule = {
-        'reports.scheduler': {
-            'task': 'reports.scheduler',
-            'schedule': crontab(minute='*', hour='*'),
+        "reports.scheduler": {
+            "task": "reports.scheduler",
+            "schedule": crontab(minute="*", hour="*"),
         },
-        'reports.prune_log': {
-            'task': 'reports.prune_log',
-            'schedule': crontab(minute=0, hour=0),
+        "reports.prune_log": {
+            "task": "reports.prune_log",
+            "schedule": crontab(minute=0, hour=0),
         },
         "cache-warmup-daily": {
             "task": "cache-warmup",
@@ -80,23 +85,23 @@ class CeleryConfig(object):
                 "top_n": 10,
                 "since": "7 days ago",
             },
-        }
+        },
     }
 
 
 CELERY_CONFIG = CeleryConfig
 
 FEATURE_FLAGS = {
-    flag_name: os.getenv(flag_name, '').lower() != 'false'
+    flag_name: os.getenv(flag_name, "").lower() != "false"
     for flag_name in [
-        'ALERTS_ATTACH_REPORTS',
-        'DASHBOARD_CROSS_FILTERS',
-        'DASHBOARD_RBAC',
-        'EMBEDDABLE_CHARTS',
-        'SCHEDULED_QUERIES',
-        'ESTIMATE_QUERY_COST',
-        'ENABLE_TEMPLATE_PROCESSING',
-        'ALERT_REPORTS'
+        "ALERTS_ATTACH_REPORTS",
+        "DASHBOARD_CROSS_FILTERS",
+        "DASHBOARD_RBAC",
+        "EMBEDDABLE_CHARTS",
+        "SCHEDULED_QUERIES",
+        "ESTIMATE_QUERY_COST",
+        "ENABLE_TEMPLATE_PROCESSING",
+        "ALERT_REPORTS",
     ]
 }
 
@@ -109,37 +114,40 @@ ENABLE_TIME_ROTATE = True
 # postgresql metadata db
 SQLALCHEMY_DATABASE_URI = os.getenv("SQL_ALCHEMY_URI")
 
-#OAUTH configuration
+# OAUTH configuration
 required_auth_vars = ["GOOGLE_KEY", "GOOGLE_SECRET", "OAUTH_DOMAIN"]
 
 if all(os.getenv(var) for var in required_auth_vars):
     AUTH_TYPE = AUTH_OAUTH
     CUSTOM_SECURITY_MANAGER = CustomSsoSecurityManager
     OAUTH_PROVIDERS = [
-            {
-                "name": "google",
-                "icon": "fa-google",
-                "token_key": "access_token",
-                "remote_app": {
-                    "client_id": os.getenv("GOOGLE_KEY"),
-                    "client_secret": os.getenv("GOOGLE_SECRET"),
-                    "api_base_url": "https://www.googleapis.com/oauth2/v2/",
-                    "client_kwargs": {"scope": "email profile openid"},
-                    "request_token_url": None,
-                    "access_token_url": "https://accounts.google.com/o/oauth2/token",
-                    "authorize_url": "https://accounts.google.com/o/oauth2/auth",
-                    "authorize_params": {"hd": os.getenv("OAUTH_DOMAIN", "")},
-                    "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
-                },
+        {
+            "name": "google",
+            "icon": "fa-google",
+            "token_key": "access_token",
+            "remote_app": {
+                "client_id": os.getenv("GOOGLE_KEY"),
+                "client_secret": os.getenv("GOOGLE_SECRET"),
+                "api_base_url": "https://www.googleapis.com/oauth2/v2/",
+                "client_kwargs": {"scope": "email profile openid"},
+                "request_token_url": None,
+                "access_token_url": "https://accounts.google.com/o/oauth2/token",
+                "authorize_url": "https://accounts.google.com/o/oauth2/auth",
+                "authorize_params": {"hd": os.getenv("OAUTH_DOMAIN", "")},
+                "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
             },
-        ]
+        },
+    ]
 
-    # Will allow user self registration, allowing to create Flask users from Authorized User
+    # Will allow user self registration, creates Flask user from Authorized User
     AUTH_USER_REGISTRATION = True
 
     # The custom logic for user self registration role
     admin_users = os.getenv("OAUTH_ADMIN_EMAIL")
-    AUTH_USER_REGISTRATION_ROLE_JMESPATH=f"contains(['{admin_users}'], email) && 'Admin' || 'Gamma'"
+    default_role = os.getenv("SELF_REGISTRATION_ROLE")
+    AUTH_USER_REGISTRATION_ROLE_JMESPATH = (
+        f"contains(['{admin_users}'], email) && 'Admin' || '{default_role}'"
+    )
 
     # For Google https redirect
     ENABLE_PROXY_FIX = True

--- a/templates/superset_config.py
+++ b/templates/superset_config.py
@@ -122,11 +122,12 @@ if all(os.getenv(var) for var in required_auth_vars):
                     "client_id": os.getenv("GOOGLE_KEY"),
                     "client_secret": os.getenv("GOOGLE_SECRET"),
                     "api_base_url": "https://www.googleapis.com/oauth2/v2/",
-                    "client_kwargs": {"scope": "email profile"},
+                    "client_kwargs": {"scope": "email profile openid"},
                     "request_token_url": None,
                     "access_token_url": "https://accounts.google.com/o/oauth2/token",
                     "authorize_url": "https://accounts.google.com/o/oauth2/auth",
-                    "authorize_params": {"hd": os.getenv("OAUTH_DOMAIN", "")}
+                    "authorize_params": {"hd": os.getenv("OAUTH_DOMAIN", "")},
+                    "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
                 },
             }
         ]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -40,7 +40,7 @@ async def deploy(ops_test: OpsTest):
             apps=[NGINX_NAME, POSTGRES_NAME, REDIS_NAME],
             status="active",
             raise_on_blocked=False,
-            timeout=600,
+            timeout=2000,
         )
 
     for function, alias in CHARM_FUNCTIONS.items():

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -104,6 +104,11 @@ class TestCharm(TestCase):
                         "SQLALCHEMY_POOL_SIZE": 5,
                         "SQLALCHEMY_POOL_TIMEOUT": 300,
                         "SQLALCHEMY_MAX_OVERFLOW": 10,
+                        "GOOGLE_KEY": None,
+                        "GOOGLE_SECRET": None,
+                        "OAUTH_DOMAIN": None,
+                        "OAUTH_ADMIN_EMAIL": "admin@superset.com",
+                        "SELF_REGISTRATION_ROLE": "Public",
                     },
                     "on-check-failure": {"up": "ignore"},
                 }
@@ -186,6 +191,11 @@ class TestCharm(TestCase):
                         "SQLALCHEMY_POOL_SIZE": 5,
                         "SQLALCHEMY_POOL_TIMEOUT": 300,
                         "SQLALCHEMY_MAX_OVERFLOW": 10,
+                        "GOOGLE_KEY": None,
+                        "GOOGLE_SECRET": None,
+                        "OAUTH_DOMAIN": None,
+                        "OAUTH_ADMIN_EMAIL": "admin@superset.com",
+                        "SELF_REGISTRATION_ROLE": "Public",
                     },
                     "on-check-failure": {"up": "ignore"},
                 },
@@ -224,7 +234,7 @@ class TestCharm(TestCase):
             "service-hostname": harness.charm.app.name,
             "service-name": harness.charm.app.name,
             "service-port": SERVER_PORT,
-            "backend-protocol": "HTTPS",
+            "backend-protocol": "HTTP",
             "tls-secret-name": "superset-tls",
         }
 


### PR DESCRIPTION
Adds Google Oauth and related config values to the superset charm.

It also:
- Reverts the addition of a generated username to the `admin` user, as this will be easier for username and password authentication on reflection.
- Removes the Talisman policy as their are bugs associated with using this and Oauth that are yet to be resolved: https://github.com/apache/superset/issues/24579.
- Fixes the backend protocol which needed updating after changes to the nginx_ingress_library