### PR TITLE
add on peer relation and testing for scaling

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -11,6 +11,7 @@ jobs:
         tox-environments:
           - integration-charm
           - integration-upgrades
+          - integration-scaling
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -150,11 +150,11 @@ juju run postgresql-k8s/leader restore backup-id=YYYY-MM-DDTHH:MM:SSZ --wait 5m
 More details found [here](https://charmhub.io/postgresql-k8s/docs/h-restore-backup).
 
 ## Scaling
-The Superset charm consists of 3 services (server, worker and beat), the server and worker services are independently scalable.
+The Superset charm consists of 3 services deployed as separate applications (below), which scale independently.
 - Server (`app-gunicorn`): Web server.
 - Worker (`worker`): for execution of jobs.
 - Beat (`beat`): for job scheduling.
-Communication between these services is via Redis which acts as a message broker. Due to the nature of the beat scheduler, it should not be scaled as this could cause some conflicing schedules. The remaining services can be scaled according to your needs.
+Communication between these applications is via Redis which acts as a message broker. Due to the nature of the beat scheduler, it should not be scaled as this could cause some conflicing schedules. The remaining applications can be scaled according to your needs.
 
 To scale an application, run:
 ```

--- a/lib/charms/redis_k8s/v0/redis.py
+++ b/lib/charms/redis_k8s/v0/redis.py
@@ -7,6 +7,11 @@ Import `RedisRequires` in your charm by adding the following to `src/charm.py`:
 ```
 from charms.redis_k8s.v0.redis import RedisRequires
 ```
+Define the following attributes in charm charm class for the library to be able to work with it
+```
+ _stored = StoredState()
+    on = RedisRelationCharmEvents()
+```
 And then in your charm's `__init__` method:
 ```
 # Make sure you set redis_relation in StoredState. Assuming you refer to this
@@ -15,14 +20,10 @@ self._stored.set_default(redis_relation={})
 self.redis = RedisRequires(self, self._stored)
 ```
 And then wherever you need to reference the relation data it will be available
-via StoredState:
+in the property `relation_data`:
 ```
-redis_hosts = []
-for redis_unit in self._stored.redis_relation:
-    redis_hosts.append({
-        "redis-host": self._stored.redis_relation[redis_unit]["hostname"],
-        "redis-port": self._stored.redis_relation[redis_unit]["port"],
-    })
+redis_host = self.redis.relation_data.get("hostname")
+redis_port = self.redis.relation_data.get("port")
 ```
 You will also need to add the following to `metadata.yaml`:
 ```
@@ -46,7 +47,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version.
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -199,3 +199,24 @@ async def simulate_crash(ops_test: OpsTest):
     await deploy_and_relate_superset_charm(
         ops_test, UI_NAME, UI_CONFIG, charm, resources
     )
+
+async def scale(ops_test: OpsTest, app, units):
+    """Scale the application to the provided number and wait for idle.
+
+    Args:
+        ops_test: PyTest object.
+        app: Application to be scaled.
+        units: Number of units required.
+    """
+    await ops_test.model.applications[app].scale(scale=units)
+
+    # Wait for model to settle
+    await ops_test.model.wait_for_idle(
+        apps=[app],
+        status="active",
+        idle_period=30,
+        raise_on_blocked=True,
+        timeout=600,
+        wait_for_exact_units=units,
+    )
+

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -1,0 +1,38 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Superset charm scaling integration tests."""
+
+import logging
+
+import pytest
+import pytest_asyncio
+from helpers import (
+    get_access_token,
+    get_unit_url,
+    scale,
+)
+from pytest_operator.plugin import OpsTest
+
+SCALABLE_SERVICES = ["superset-k8s-ui", "superset-k8s-worker"]
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.usefixtures("deploy")
+class TestScaling:
+    """Integration tests for Superset charm."""
+
+    async def test_scaling_up(self, ops_test: OpsTest):
+        """Scale Superset charms up to 2 units."""
+        for service in SCALABLE_SERVICES:
+            await scale(ops_test, app=service, units=2)
+            assert len(ops_test.model.applications[service].units) == 2
+
+        
+    async def test_scaling_down(self, ops_test: OpsTest):
+        """Scale Superset charm down to 1 unit."""
+        for service in SCALABLE_SERVICES:
+            await scale(ops_test, app=service, units=1)
+            assert len(ops_test.model.applications[service].units) == 1

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -3,36 +3,88 @@
 
 """Superset charm scaling integration tests."""
 
+import asyncio
 import logging
 
 import pytest
 import pytest_asyncio
 from helpers import (
-    get_access_token,
-    get_unit_url,
+    METADATA,
+    POSTGRES_NAME,
+    REDIS_NAME,
+    SCALABLE_SERVICES,
+    SUPERSET_SECRET_KEY,
+    deploy_and_relate_superset_charm,
+    get_active_workers,
     scale,
 )
 from pytest_operator.plugin import OpsTest
 
-SCALABLE_SERVICES = ["superset-k8s-ui", "superset-k8s-worker"]
+SCALABLE_APPS = ["superset-k8s-ui", "superset-k8s-worker"]
 
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.skip_if_deployed
+@pytest_asyncio.fixture(name="deploy-scale", scope="module")
+async def deploy(ops_test: OpsTest):
+    """Deploy the app."""
+    asyncio.gather(
+        ops_test.model.deploy(POSTGRES_NAME, channel="14", trust=True),
+        ops_test.model.deploy(REDIS_NAME, channel="edge", trust=True),
+    )
+
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[POSTGRES_NAME, REDIS_NAME],
+            status="active",
+            raise_on_blocked=False,
+            timeout=2000,
+        )
+
+        charm = await ops_test.build_charm(".")
+        resources = {
+            "superset-image": METADATA["resources"]["superset-image"][
+                "upstream-source"
+            ]
+        }
+        # Iterate through UI and worker charms
+        for function, alias in SCALABLE_SERVICES.items():
+            app_name = f"superset-k8s-{alias}"
+            superset_config = {
+                "charm-function": function,
+                "superset-secret-key": SUPERSET_SECRET_KEY,
+            }
+
+            await deploy_and_relate_superset_charm(
+                ops_test, app_name, superset_config, charm, resources
+            )
+
+        assert (
+            ops_test.model.applications[app_name].units[0].workload_status
+            == "active"
+        )
+
+
 @pytest.mark.abort_on_fail
-@pytest.mark.usefixtures("deploy")
+@pytest.mark.usefixtures("deploy-scale")
 class TestScaling:
     """Integration tests for Superset charm."""
 
     async def test_scaling_up(self, ops_test: OpsTest):
         """Scale Superset charms up to 2 units."""
-        for service in SCALABLE_SERVICES:
+        for service in SCALABLE_APPS:
             await scale(ops_test, app=service, units=2)
             assert len(ops_test.model.applications[service].units) == 2
 
-        
+        active_workers = await get_active_workers(ops_test)
+        assert len(active_workers) == 2
+
     async def test_scaling_down(self, ops_test: OpsTest):
         """Scale Superset charm down to 1 unit."""
-        for service in SCALABLE_SERVICES:
+        for service in SCALABLE_APPS:
             await scale(ops_test, app=service, units=1)
             assert len(ops_test.model.applications[service].units) == 1
+
+        active_workers = await get_active_workers(ops_test)
+        assert len(active_workers) == 1

--- a/tests/integration/test_upgrades.py
+++ b/tests/integration/test_upgrades.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.skip_if_deployed
-@pytest_asyncio.fixture(name="deploy", scope="module")
+@pytest_asyncio.fixture(name="deploy-upgrade", scope="module")
 async def deploy(ops_test: OpsTest):
     """Deploy the app."""
     asyncio.gather(
@@ -49,7 +49,7 @@ async def deploy(ops_test: OpsTest):
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.usefixtures("deploy")
+@pytest.mark.usefixtures("deploy-upgrade")
 class TestUpgrade:
     """Integration test for Superset charm upgrade from previous release."""
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ deps =
     ipdb==0.13.9
     juju==3.1.0.1
     pytest==7.4.0
+    pytest-asyncio==0.21
     pytest-operator==0.29.0
     -r{toxinidir}/requirements.txt
 commands =
@@ -40,6 +41,7 @@ deps =
     ipdb==0.13.9
     juju==3.1.0.1
     pytest==7.4.0
+    pytest-asyncio==0.21
     pytest-operator==0.29.0
     -r{toxinidir}/requirements.txt
 commands =
@@ -51,6 +53,7 @@ deps =
     ipdb==0.13.9
     juju==3.1.0.1
     pytest==7.4.0
+    pytest-asyncio==0.21
     pytest-operator==0.29.0
     -r{toxinidir}/requirements.txt
 commands =
@@ -62,7 +65,10 @@ deps =
     ipdb==0.13.9
     juju==3.1.0.1
     pytest==7.4.0
+    pytest-asyncio==0.21
     pytest-operator==0.29.0
+    celery==5.3.6
+    redis==5.0.1
     -r{toxinidir}/requirements.txt
 commands =
     pytest {[vars]tst_path}integration/test_scaling.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ deps =
     pytest-asyncio==0.21
     pytest-operator==0.29.0
     celery==5.3.6
+    protobuf==3.19.0
     -r{toxinidir}/requirements.txt
 commands =
    pytest {[vars]tst_path}integration -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
@@ -45,6 +46,7 @@ deps =
     pytest-asyncio==0.21
     pytest-operator==0.29.0
     celery==5.3.6
+    protobuf==3.19.0
     -r{toxinidir}/requirements.txt
 commands =
     pytest {[vars]tst_path}integration/test_charm.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
@@ -58,6 +60,7 @@ deps =
     pytest-asyncio==0.21
     pytest-operator==0.29.0
     celery==5.3.6
+    protobuf==3.19.0
     -r{toxinidir}/requirements.txt
 commands =
     pytest {[vars]tst_path}integration/test_upgrades.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
@@ -72,6 +75,7 @@ deps =
     pytest-operator==0.29.0
     celery==5.3.6
     redis==5.0.1
+    protobuf==3.19.0
     -r{toxinidir}/requirements.txt
 commands =
     pytest {[vars]tst_path}integration/test_scaling.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ deps =
     pytest==7.4.0
     pytest-asyncio==0.21
     pytest-operator==0.29.0
+    celery==5.3.6
     -r{toxinidir}/requirements.txt
 commands =
    pytest {[vars]tst_path}integration -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
@@ -43,6 +44,7 @@ deps =
     pytest==7.4.0
     pytest-asyncio==0.21
     pytest-operator==0.29.0
+    celery==5.3.6
     -r{toxinidir}/requirements.txt
 commands =
     pytest {[vars]tst_path}integration/test_charm.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
@@ -55,6 +57,7 @@ deps =
     pytest==7.4.0
     pytest-asyncio==0.21
     pytest-operator==0.29.0
+    celery==5.3.6
     -r{toxinidir}/requirements.txt
 commands =
     pytest {[vars]tst_path}integration/test_upgrades.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,17 @@ deps =
 commands =
     pytest {[vars]tst_path}integration/test_upgrades.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
 
+[testenv:integration-scaling]
+description = Run integration tests
+deps =
+    ipdb==0.13.9
+    juju==3.1.0.1
+    pytest==7.4.0
+    pytest-operator==0.29.0
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest {[vars]tst_path}integration/test_scaling.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+
 [testenv:unit]
 description = Run tests
 deps =


### PR DESCRIPTION
This PR adds scaling via leadership checks and information passing to non-leaders via the `on_peer_relation_updated` hook. 

It includes integration tests which:
- Deploy Superset UI and Superset worker charms
- Integrate these with PostgreSQL and Redis charms
- Scales both charms to 2
- Verifies there are now 2 active workers
- Reduces the scale to 2 
- Verifies there is now 1 active worker

It also adds documentation on the scaling process in the `README` please note that I plan to create a documentation PR similar to temporal which will split this out into more of a tutorial style format.

Note: `pytest-asyncio==0.21` was required to be added to all integration tests as a result of a recent update of `pytest` which resulted in breaking changes.