### PR TITLE
make relations superset db admins

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -72,7 +72,10 @@ class SupersetK8SCharm(TypedCharmBase[CharmConfig]):
 
         # Handle postgresql relation
         self.postgresql_db = DatabaseRequires(
-            self, relation_name="postgresql_db", database_name="superset"
+            self,
+            relation_name="postgresql_db",
+            database_name="superset",
+            extra_user_roles="admin",
         )
         self.database = Database(self)
 


### PR DESCRIPTION
Without this admin role the owner of the table becomes the only user (ie. relation) that can perform actions on a table. This is fine when the order of relation with postgresql is controlled but this is not possible/recommended with a Terraform deployment. 