### PR TITLE
Add defer on can't connect to pebble

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -278,6 +278,7 @@ class SupersetK8SCharm(TypedCharmBase[CharmConfig]):
         """
         container = self.unit.get_container(self.name)
         if not container.can_connect():
+            event.defer()
             return
 
         if not self.ready_to_start():


### PR DESCRIPTION
Adds a defer when we can't connect to pebble, a common pattern (see [here](https://juju.is/docs/sdk/deferring-events-details-and-dilemmas))