### PR TITLE
Ready to start, upgrade on edge, integration test on publish

### DIFF
--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -13,4 +13,4 @@ jobs:
       integration-test-provider: microk8s
       integration-test-provider-channel: 1.25-strict/stable
       integration-test-juju-channel: 3.1/stable
-      integration-test-modules: '["test_charm"]'
+      integration-test-modules: '["test_charm", "test_scaling", "test_upgrades"]'

--- a/src/charm.py
+++ b/src/charm.py
@@ -214,15 +214,16 @@ class SupersetK8SCharm(TypedCharmBase[CharmConfig]):
             return False
 
         if not self._state.postgresql_relation:
-            self.unit.status = BlockedStatus("Needs a PostgreSQL relation")
+            self.unit.status = BlockedStatus("Needs a PostgreSQL relation.")
             return False
 
         if not self._state.redis_relation:
-            self.unit.status = BlockedStatus("Needs a Redis relation")
+            self.unit.status = BlockedStatus("Needs a Redis relation.")
             return False
 
         container = self.unit.get_container(self.name)
         if not container.can_connect():
+            self.unit.status = WaitingStatus("Waiting for pebble ready.")
             return False
         return True
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -220,6 +220,10 @@ class SupersetK8SCharm(TypedCharmBase[CharmConfig]):
         if not self._state.redis_relation:
             self.unit.status = BlockedStatus("Needs a Redis relation")
             return False
+
+        container = self.unit.get_container(self.name)
+        if not container.can_connect():
+            return False
         return True
 
     @log_event_handler(logger)
@@ -300,8 +304,6 @@ class SupersetK8SCharm(TypedCharmBase[CharmConfig]):
             event: The event triggered when the relation changed.
         """
         container = self.unit.get_container(self.name)
-        if not container.can_connect():
-            return
 
         if not self.ready_to_start():
             return

--- a/tests/integration/test_upgrades.py
+++ b/tests/integration/test_upgrades.py
@@ -43,7 +43,7 @@ async def deploy(ops_test: OpsTest):
             "superset-secret-key": SUPERSET_SECRET_KEY,
         }
         await ops_test.model.deploy(
-            APP_NAME, channel="stable", config=superset_config
+            APP_NAME, channel="edge", config=superset_config
         )
         await perform_superset_integrations(ops_test, APP_NAME)
 


### PR DESCRIPTION
A few minor updates to the Superset Charm:
- Moved check for container connection to `ready_to_start` for consistency and add status with message.
- Have the upgrade integration test, testing upgrade on `edge` as opposed to `stable` as suggested by Ali in https://github.com/canonical/ranger-k8s-operator/pull/20
- Ensure that all integration tests are being run on publish of the charm.