### PR TITLE
Update sentry init in line with older versions of the sdk

### DIFF
--- a/templates/superset_config.py
+++ b/templates/superset_config.py
@@ -23,9 +23,8 @@ if all([SENTRY_DSN, SENTRY_ENVIRONMENT, SENTRY_RELEASE]):
         dsn=SENTRY_DSN,
         environment=SENTRY_ENVIRONMENT,
         release=SENTRY_RELEASE,
-        sample_rate=SENTRY_SAMPLE_RATE,
+        sample_rate=float(SENTRY_SAMPLE_RATE),
         before_send=sentry_before_send,
-        enable_tracing=True,
         )
 
 # Redis caching


### PR DESCRIPTION
Since we will be using an older version of the sentry-sdk - the `sentry_sdk.init` parameters need to be updated accordingly.