### PR TITLE
Fix Celery Cache Warmup

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -190,6 +190,6 @@ options:
     default: false
     type: boolean
   server-alias:
-    description: The alias a charm has been deployed with if it differs from the default.
+    description: The alias the server charm has been deployed with if it differs from the default.
     default: superset-k8s
     type: string

--- a/config.yaml
+++ b/config.yaml
@@ -189,3 +189,7 @@ options:
     description: Indicates whether or not event parameters sent to Sentry should be redacted.
     default: false
     type: boolean
+  server-alias:
+    description: The alias a charm has been deployed with if it differs from the default.
+    default: superset-k8s
+    type: string

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -320,7 +320,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 27
+LIBPATCH = 28
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -1796,6 +1796,17 @@ class DatabaseProvidesEvent(RelationEvent):
 class DatabaseRequestedEvent(DatabaseProvidesEvent, ExtraRoleEvent):
     """Event emitted when a new database is requested for use on this relation."""
 
+    @property
+    def external_node_connectivity(self) -> bool:
+        """Returns the requested external_node_connectivity field."""
+        if not self.relation.app:
+            return False
+
+        return (
+            self.relation.data[self.relation.app].get("external-node-connectivity", "false")
+            == "true"
+        )
+
 
 class DatabaseProvidesEvents(CharmEvents):
     """Database events.
@@ -2014,11 +2025,13 @@ class DatabaseRequires(DataRequires):
         extra_user_roles: Optional[str] = None,
         relations_aliases: Optional[List[str]] = None,
         additional_secret_fields: Optional[List[str]] = [],
+        external_node_connectivity: bool = False,
     ):
         """Manager of database client relations."""
         super().__init__(charm, relation_name, extra_user_roles, additional_secret_fields)
         self.database = database_name
         self.relations_aliases = relations_aliases
+        self.external_node_connectivity = external_node_connectivity
 
         # Define custom event names for each alias.
         if relations_aliases:
@@ -2169,16 +2182,16 @@ class DatabaseRequires(DataRequires):
         if not self.local_unit.is_leader():
             return
 
+        event_data = {"database": self.database}
+
         if self.extra_user_roles:
-            self.update_relation_data(
-                event.relation.id,
-                {
-                    "database": self.database,
-                    "extra-user-roles": self.extra_user_roles,
-                },
-            )
-        else:
-            self.update_relation_data(event.relation.id, {"database": self.database})
+            event_data["extra-user-roles"] = self.extra_user_roles
+
+        # set external-node-connectivity field
+        if self.external_node_connectivity:
+            event_data["external-node-connectivity"] = "true"
+
+        self.update_relation_data(event.relation.id, event_data)
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the database relation has changed."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -306,6 +306,8 @@ class SupersetK8SCharm(TypedCharmBase[CharmConfig]):
             "SENTRY_ENVIRONMENT": self.config["sentry-environment"],
             "SENTRY_REDACT_PARAMS": self.config["sentry-redact-params"],
             "SENTRY_SAMPLE_RATE": self.config["sentry-sample-rate"],
+            "SERVER_ALIAS": self.config["server-alias"],
+            "APPLICATION_PORT": APPLICATION_PORT,
         }
         return env
 
@@ -353,6 +355,10 @@ class SupersetK8SCharm(TypedCharmBase[CharmConfig]):
                     }
                 },
             )
+
+            # Open port for cache warm-up.
+            self.model.unit.open_port(port=APPLICATION_PORT, protocol="tcp")
+
         container.add_layer(self.name, pebble_layer, combine=True)
         container.replan()
         self.unit.status = MaintenanceStatus("replanning application")

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -82,6 +82,7 @@ class CharmConfig(BaseConfigModel):
     sentry_environment: Optional[str]
     sentry_redact_params: bool
     sentry_sample_rate: Optional[str]
+    server_alias: str
 
     @validator("*", pre=True)
     @classmethod

--- a/templates/superset_config.py
+++ b/templates/superset_config.py
@@ -6,6 +6,8 @@ from custom_sso_security_manager import CustomSsoSecurityManager
 from sentry_interceptor import redact_params
 import sentry_sdk
 
+APPLICATION_PORT = os.getenv("APPLICATION_PORT")
+SERVER_ALIAS = os.getenv("SERVER_ALIAS")
 
 # Monitoring with Sentry
 SENTRY_DSN = os.getenv("SENTRY_DSN")
@@ -66,7 +68,7 @@ SQLALCHEMY_POOL_SIZE = int(os.getenv("SQLALCHEMY_POOL_SIZE"))
 SQLALCHEMY_POOL_TIMEOUT = int(os.getenv("SQLALCHEMY_POOL_TIMEOUT"))
 SQLALCHEMY_MAX_OVERFLOW = int(os.getenv("SQLALCHEMY_MAX_OVERFLOW"))
 
-
+# Celery cache warm-up
 class CeleryConfig(object):
     broker_url = (
         f"redis://{os.getenv('REDIS_HOST')}:{os.getenv('REDIS_PORT')}/4"
@@ -104,6 +106,7 @@ class CeleryConfig(object):
 
 
 CELERY_CONFIG = CeleryConfig
+WEBDRIVER_BASEURL = f"http://{SERVER_ALIAS}:{APPLICATION_PORT}/"
 
 FEATURE_FLAGS = {
     flag_name: os.getenv(flag_name, "").lower() != "false"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -54,6 +54,7 @@ async def deploy(ops_test: OpsTest):
             superset_config = {
                 "charm-function": function,
                 "superset-secret-key": SUPERSET_SECRET_KEY,
+                "server-alias": UI_NAME,
             }
 
             # Load examples for the UI charm

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -14,6 +14,7 @@ from helpers import (
     REDIS_NAME,
     SCALABLE_SERVICES,
     SUPERSET_SECRET_KEY,
+    UI_NAME,
     deploy_and_relate_superset_charm,
     get_active_workers,
     scale,
@@ -54,6 +55,7 @@ async def deploy(ops_test: OpsTest):
             superset_config = {
                 "charm-function": function,
                 "superset-secret-key": SUPERSET_SECRET_KEY,
+                "server-alias": UI_NAME,
             }
 
             await deploy_and_relate_superset_charm(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -122,6 +122,8 @@ class TestCharm(TestCase):
                         "SENTRY_RELEASE": None,
                         "SENTRY_REDACT_PARAMS": False,
                         "SENTRY_SAMPLE_RATE": 1.0,
+                        "SERVER_ALIAS": "superset-k8s",
+                        "APPLICATION_PORT": 8088,
                     },
                     "on-check-failure": {"up": "ignore"},
                 }
@@ -210,6 +212,8 @@ class TestCharm(TestCase):
                         "SENTRY_RELEASE": None,
                         "SENTRY_REDACT_PARAMS": False,
                         "SENTRY_SAMPLE_RATE": 1.0,
+                        "SERVER_ALIAS": "superset-k8s",
+                        "APPLICATION_PORT": 8088,
                     },
                     "on-check-failure": {"up": "ignore"},
                 },


### PR DESCRIPTION
Resolves this bug: https://warthogs.atlassian.net/browse/CSS-7244

Please note that the celery worker needs the host of the server application which depends on the name given when deploying the application. This information should be transferred in a relation between the server and celery charm but at the moment no such relation exists. I have created a Jira ticket for separating the server, worker and beat charms and providing relations between them: https://warthogs.atlassian.net/browse/CSS-7260. But in order to resolve this error in the meantime I have made this a customizable config. 