### PR TITLE
Adds the Canonical role as a possible self-registration-role value

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,6 +11,8 @@ parts:
       - libssl-dev
       - rustc
       - cargo
+    charm-binary-python-packages:
+      - psycopg2-binary
 bases:
   - build-on:
     - name: ubuntu

--- a/config.yaml
+++ b/config.yaml
@@ -122,7 +122,6 @@ options:
   self-registration-role:
     description: |
       The default role to be provided to users that self-register via Oauth.
-      One of `Admin`, `Alpha`, `Gamma`, `Public`, `sql_lab`, `Canonical`
     type: string
     default: Public
   http-proxy:

--- a/config.yaml
+++ b/config.yaml
@@ -122,7 +122,7 @@ options:
   self-registration-role:
     description: |
       The default role to be provided to users that self-register via Oauth.
-      One of `Admin`, `Alpha`, `Gamma`, `Public`, `sql_lab`
+      One of `Admin`, `Alpha`, `Gamma`, `Public`, `sql_lab`, `Canonical`
     type: string
     default: Public
   http-proxy:

--- a/config.yaml
+++ b/config.yaml
@@ -122,6 +122,7 @@ options:
   self-registration-role:
     description: |
       The default role to be provided to users that self-register via Oauth.
+      This role must exist already in Superset and is case sensitive.
     type: string
     default: Public
   http-proxy:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ops >= 2.2.0
 pydantic==1.10.12
+sqlalchemy<2.0

--- a/src/charm.py
+++ b/src/charm.py
@@ -282,9 +282,7 @@ class SupersetK8SCharm(TypedCharmBase[CharmConfig]):
             "GOOGLE_SECRET": self.config["google-client-secret"],
             "OAUTH_DOMAIN": self.config["oauth-domain"],
             "OAUTH_ADMIN_EMAIL": self.config["oauth-admin-email"],
-            "SELF_REGISTRATION_ROLE": self.config[
-                "self-registration-role"
-            ].value,
+            "SELF_REGISTRATION_ROLE": self.config["self-registration-role"],
             "HTTP_PROXY": self.config["http-proxy"],
             "HTTPS_PROXY": self.config["https-proxy"],
             "NO_PROXY": self.config["no-proxy"],

--- a/src/literals.py
+++ b/src/literals.py
@@ -13,3 +13,5 @@ CONFIG_FILES = [
 ]
 CONFIG_PATH = "/app/pythonpath"
 UI_FUNCTIONS = ["app", "app-gunicorn"]
+DEFAULT_ROLES = ["Public", "Gamma", "Alpha", "Admin"]
+SQL_AB_ROLE = "SELECT name FROM ab_role;"

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -42,6 +42,7 @@ class RegistrationRole(str, Enum):
     gamma = "Gamma"
     public = "Public"
     sql_lab = "sql_lab"
+    canonical = "Canonical"
 
 
 class CharmConfig(BaseConfigModel):

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -34,17 +34,6 @@ class FunctionType(str, Enum):
     beat = "beat"
 
 
-class RegistrationRole(str, Enum):
-    """Enum for the `self-registration-role` field."""
-
-    admin = "Admin"
-    alpha = "Alpha"
-    gamma = "Gamma"
-    public = "Public"
-    sql_lab = "sql_lab"
-    canonical = "Canonical"
-
-
 class CharmConfig(BaseConfigModel):
     """Manager for the structured configuration."""
 
@@ -64,7 +53,7 @@ class CharmConfig(BaseConfigModel):
     sqlalchemy_pool_size: int
     sqlalchemy_pool_timeout: int
     sqlalchemy_max_overflow: int
-    self_registration_role: RegistrationRole
+    self_registration_role: str
     oauth_admin_email: str
     google_client_id: Optional[str]
     google_client_secret: Optional[str]

--- a/src/utils.py
+++ b/src/utils.py
@@ -9,6 +9,9 @@ import os
 import secrets
 import string
 
+from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError
+
 from literals import CONFIG_FILES, CONFIG_PATH
 
 logger = logging.getLogger(__name__)
@@ -73,3 +76,23 @@ def load_superset_files(container):
     for file in CONFIG_FILES:
         path = CONFIG_PATH
         push_files(container, f"templates/{file}", f"{path}/{file}", 0o744)
+
+
+def query_metadata_database(uri, sql):
+    """Query metadata database.
+
+    Args:
+        uri: database uri string.
+        sql: SQL query to execute.
+
+    Return:
+        List of returned values.
+    """
+    try:
+        engine = create_engine(uri)
+        with engine.connect() as connection:
+            result = connection.execute(sql)
+            return [row[0] for row in result.fetchall()]
+    except SQLAlchemyError as e:
+        logger.exception("Error accessing database: %s", str(e))
+        return []

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -363,6 +363,16 @@ class TestCharm(TestCase):
             MaintenanceStatus("replanning application"),
         )
 
+    def test_invalid_default_role(self):
+        """The pebble plan reflects the worker function."""
+        harness = self.harness
+
+        simulate_lifecycle(harness)
+        with self.assertRaises(ValueError):
+            self.harness.update_config(
+                {"self-registration-role": "InvalidRole"}
+            )
+
 
 @mock.patch("charm.Redis._get_redis_relation_data")
 def simulate_lifecycle(harness, _get_redis_relation_data):

--- a/tests/unit/test_structured_config.py
+++ b/tests/unit/test_structured_config.py
@@ -45,11 +45,6 @@ def test_product_related_values(_harness) -> None:
     accepted_values = ["app-gunicorn", "worker", "beat"]
     check_valid_values(_harness, "charm-function", accepted_values)
 
-    # self-registration-role
-    check_invalid_values(_harness, "self-registration-role", erroneus_values)
-    accepted_values = ["Admin", "Alpha", "Gamma", "Public", "sql_lab"]
-    check_valid_values(_harness, "self-registration-role", accepted_values)
-
 
 def check_valid_values(_harness, field: str, accepted_values: list) -> None:
     """Check the correctness of the passed values for a field.

--- a/tox.ini
+++ b/tox.ini
@@ -86,6 +86,7 @@ deps =
     coverage[toml]==6.4.4
     ipdb==0.13.9
     pytest==7.1.3
+    psycopg2-binary==2.9.9
     -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \


### PR DESCRIPTION
In order to allow the role assigned on automatic registration via authentication to be configurable. The only requirement of this value is that the Role must already exist (creation via the UI).

Note: the decision to use `ValueError` instead of `BlockedStatus` is to keep this aligned with the behaviour of the structured config. And the data platform team best practices which is to prevent any other event occurring on an incorrect config.