### PR TITLE
Add webserver_timeout value to config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -193,3 +193,7 @@ options:
     description: The alias the server charm has been deployed with if it differs from the default.
     default: superset-k8s
     type: string
+  webserver-timeout:
+    description: The time in seconds the server can maintain a database connection.
+    default: 180
+    type: int

--- a/src/charm.py
+++ b/src/charm.py
@@ -332,6 +332,7 @@ class SupersetK8SCharm(TypedCharmBase[CharmConfig]):
             "SENTRY_SAMPLE_RATE": self.config["sentry-sample-rate"],
             "SERVER_ALIAS": self.config["server-alias"],
             "APPLICATION_PORT": APPLICATION_PORT,
+            "WEBSERVER_TIMEOUT": self.config["webserver-timeout"],
         }
         return env
 

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -73,6 +73,7 @@ class CharmConfig(BaseConfigModel):
     sentry_redact_params: bool
     sentry_sample_rate: Optional[str]
     server_alias: str
+    webserver_timeout: int
 
     @validator("*", pre=True)
     @classmethod
@@ -176,7 +177,7 @@ class CharmConfig(BaseConfigModel):
             value: sentry_sample_rate value
 
         Returns:
-            fload_value: integer for sentry_sample_rate configuration
+            float_value: float for sentry_sample_rate configuration
 
         Raises:
             ValueError: in the case when the value is out of range
@@ -184,4 +185,23 @@ class CharmConfig(BaseConfigModel):
         float_value = float(value)
         if 0 <= float_value <= 1:
             return float_value
+        raise ValueError("Value out of range.")
+
+    @validator("webserver_timeout")
+    @classmethod
+    def webserver_timeout_validator(cls, value: str) -> Optional[float]:
+        """Check validity of `webserver_timeout` field.
+
+        Args:
+            value: webserver_timeout value
+
+        Returns:
+            int: integer for webserver_timeout configuration
+
+        Raises:
+            ValueError: in the case when the value is out of range
+        """
+        int_value = int(value)
+        if 60 <= int_value <= 300:
+            return int_value
         raise ValueError("Value out of range.")

--- a/templates/superset_config.py
+++ b/templates/superset_config.py
@@ -109,6 +109,8 @@ class CeleryConfig(object):
 CELERY_CONFIG = CeleryConfig
 WEBDRIVER_BASEURL = f"http://{SERVER_ALIAS}:{APPLICATION_PORT}/"
 
+SUPERSET_WEBSERVER_TIMEOUT = int(os.getenv("WEBSERVER_TIMEOUT"))
+
 FEATURE_FLAGS = {
     flag_name: os.getenv(flag_name, "").lower() != "false"
     for flag_name in [

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -35,10 +35,16 @@ async def deploy(ops_test: OpsTest):
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
-            apps=[NGINX_NAME, POSTGRES_NAME, REDIS_NAME],
+            apps=[POSTGRES_NAME, REDIS_NAME],
             status="active",
             raise_on_blocked=False,
             timeout=2000,
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[NGINX_NAME],
+            status="waiting",
+            raise_on_blocked=False,
+            timeout=200,
         )
 
         charm = await ops_test.build_charm(".")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -124,6 +124,7 @@ class TestCharm(TestCase):
                         "SENTRY_SAMPLE_RATE": 1.0,
                         "SERVER_ALIAS": "superset-k8s",
                         "APPLICATION_PORT": 8088,
+                        "WEBSERVER_TIMEOUT": 180,
                     },
                     "on-check-failure": {"up": "ignore"},
                 }
@@ -214,6 +215,7 @@ class TestCharm(TestCase):
                         "SENTRY_SAMPLE_RATE": 1.0,
                         "SERVER_ALIAS": "superset-k8s",
                         "APPLICATION_PORT": 8088,
+                        "WEBSERVER_TIMEOUT": 180,
                     },
                     "on-check-failure": {"up": "ignore"},
                 },

--- a/tests/unit/test_structured_config.py
+++ b/tests/unit/test_structured_config.py
@@ -28,10 +28,14 @@ def test_config_parsing_parameters_integer_values(_harness) -> None:
         "sqlalchemy-pool-size",
         "sqlalchemy-pool-timeout",
         "sqlalchemy-max-overflow",
+        "webserver-timeout",
     ]
     erroneus_values = [2147483648, -2147483649]
     valid_values = [42, 100, 1]
+    webserver_timeout_valid_values = [60, 170, 300]
     for field in integer_fields:
+        if field == "webserver-timeout":
+            valid_values = webserver_timeout_valid_values
         check_invalid_values(_harness, field, erroneus_values)
         check_valid_values(_harness, field, valid_values)
 


### PR DESCRIPTION
For synchronous querying (which can be used with charts and dashboards) allow for an extention of the usual query timeout from 60s up to 300s (1 to 5 mins). Implementing a default of 3 minutes as this covers all but the longest growth engineering chart queries.

Also: 
-  a typo fix in the sentry structure config validation.
- Update to expected status of the nginx charm following deployment due to changes to the stable charm release.