### PR TITLE
CSS-9261 Add image allowlist and update libs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,10 @@
 # See https://juju.is/docs/config for guidance.
 
 options:
+  allow-image-domains: 
+    description: |
+        Comma separated list of domains from which to allow images according to the CSP.
+    type: string
   external-hostname:
     description: |
         The DNS listing used for external connections. 

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 35
+LIBPATCH = 36
 
 logger = logging.getLogger(__name__)
 
@@ -1050,6 +1050,7 @@ class GrafanaDashboardProvider(Object):
 
         self.framework.observe(self._charm.on.leader_elected, self._update_all_dashboards_from_dir)
         self.framework.observe(self._charm.on.upgrade_charm, self._update_all_dashboards_from_dir)
+        self.framework.observe(self._charm.on.config_changed, self._update_all_dashboards_from_dir)
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_created,

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -16,9 +16,10 @@ The provider side of the relation represents the server side, to which logs are 
   applications such as pebble, or charmed operators of workloads such as grafana-agent or promtail,
   that can communicate with loki directly.
 
-- `LogProxyConsumer`: This object can be used by any Charmed Operator which needs to
-send telemetry, such as logs, to Loki through a Log Proxy by implementing the consumer side of the
-`loki_push_api` relation interface.
+- `LogProxyConsumer`: DEPRECATED.
+This object can be used by any Charmed Operator which needs to send telemetry, such as logs, to
+Loki through a Log Proxy by implementing the consumer side of the `loki_push_api` relation
+interface.
 
 Filtering logs in Loki is largely performed on the basis of labels. In the Juju ecosystem, Juju
 topology labels are used to uniquely identify the workload which generates telemetry like logs.
@@ -38,13 +39,14 @@ and three optional arguments.
 - `charm`: A reference to the parent (Loki) charm.
 
 - `relation_name`: The name of the relation that the charm uses to interact
-  with its clients, which implement `LokiPushApiConsumer` or `LogProxyConsumer`.
+  with its clients, which implement `LokiPushApiConsumer` or `LogProxyConsumer`
+  (note that LogProxyConsumer is deprecated).
 
   If provided, this relation name must match a provided relation in metadata.yaml with the
   `loki_push_api` interface.
 
   The default relation name is "logging" for `LokiPushApiConsumer` and "log-proxy" for
-  `LogProxyConsumer`.
+  `LogProxyConsumer` (note that LogProxyConsumer is deprecated).
 
   For example, a provider's `metadata.yaml` file may look as follows:
 
@@ -218,6 +220,9 @@ labels in charm code. See :func:`LogProxyConsumer._scrape_configs` for an exampl
 to do this with promtail.
 
 ## LogProxyConsumer Library Usage
+
+> Note: This object is deprecated. Consider migrating to LogForwarder (see v1/loki_push_api) with
+> the release of Juju 3.6 LTS.
 
 Let's say that we have a workload charm that produces logs, and we need to send those logs to a
 workload implementing the `loki_push_api` interface, such as `Loki` or `Grafana Agent`.
@@ -480,7 +485,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 29
+LIBPATCH = 30
 
 PYDEPS = ["cosl"]
 
@@ -1539,7 +1544,8 @@ class LokiPushApiConsumer(ConsumerBase):
         the Loki API endpoint to push logs. It is intended for workloads that can speak
         loki_push_api (https://grafana.com/docs/loki/latest/api/#push-log-entries-to-loki), such
         as grafana-agent.
-        (If you only need to forward a few workload log files, then use LogProxyConsumer.)
+        (If you need to forward workload stdout logs, then use v1/loki_push_api.LogForwarder; if
+        you need to forward log files, then use LogProxyConsumer.)
 
         `LokiPushApiConsumer` can be instantiated as follows:
 
@@ -1727,6 +1733,9 @@ class LogProxyEvents(ObjectEvents):
 
 class LogProxyConsumer(ConsumerBase):
     """LogProxyConsumer class.
+
+    > Note: This object is deprecated. Consider migrating to v1/loki_push_api.LogForwarder with the
+    > release of Juju 3.6 LTS.
 
     The `LogProxyConsumer` object provides a method for attaching `promtail` to
     a workload in order to generate structured logging data from applications

--- a/src/charm.py
+++ b/src/charm.py
@@ -315,6 +315,7 @@ class SupersetK8SCharm(TypedCharmBase[CharmConfig]):
         self._validate_self_registration_role()
 
         env = {
+            "ALLOW_IMAGE_DOMAINS": self.config["allow-image-domains"],
             "SUPERSET_SECRET_KEY": self._state.superset_secret_key,
             "ADMIN_PASSWORD": self.config["admin-password"],
             "CHARM_FUNCTION": self.config["charm-function"].value,

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -37,6 +37,7 @@ class FunctionType(str, Enum):
 class CharmConfig(BaseConfigModel):
     """Manager for the structured configuration."""
 
+    allow_image_domains: Optional[str]
     external_hostname: str
     tls_secret_name: str
     superset_secret_key: Optional[str]

--- a/templates/superset_config.py
+++ b/templates/superset_config.py
@@ -73,11 +73,18 @@ RESULTS_BACKEND = RedisCache(
 )
 
 TALISMAN_ENABLED = True
+
+image_allow_list = ["'self'", "data:"]
+image_domains = os.getenv("ALLOW_IMAGE_DOMAINS")
+
+if image_domains:
+    image_allow_list.extend(domain.strip() for domain in image_domains.split(','))
+
 TALISMAN_CONFIG = {
      "force_https": False,
      "content_security_policy": {
         "default-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
-        "img-src": ["'self'", "data:"],
+        "img-src": image_allow_list,
         "worker-src": ["'self'", "blob:"],
         "connect-src": ["'self'", "https://api.mapbox.com", "https://events.mapbox.com"],
         "object-src": "'none'",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -84,6 +84,7 @@ class TestCharm(TestCase):
                     "command": "/app/k8s/k8s-bootstrap.sh",
                     "startup": "enabled",
                     "environment": {
+                        "ALLOW_IMAGE_DOMAINS": None,
                         "SUPERSET_SECRET_KEY": "example-pass",
                         "ADMIN_USER": "unique-user",
                         "ADMIN_PASSWORD": "admin",
@@ -167,6 +168,7 @@ class TestCharm(TestCase):
                 "http-proxy": "proxy:1234",
                 "https-proxy": "proxy:1234",
                 "no-proxy": ".canonical.com",
+                "allow-image-domains": "assets.ubuntu.com",
             }
         )
 
@@ -179,6 +181,7 @@ class TestCharm(TestCase):
                     "command": "/app/k8s/k8s-bootstrap.sh",
                     "startup": "enabled",
                     "environment": {
+                        "ALLOW_IMAGE_DOMAINS": "assets.ubuntu.com",
                         "SUPERSET_SECRET_KEY": "example-pass",
                         "ADMIN_PASSWORD": "secure-pass",
                         "ADMIN_USER": "unique-user",


### PR DESCRIPTION
This PR adds an allow list to the content security policy to enable images from listed domains to be allowed. Our use case if for `assets.ubuntu.com`. 

It also updates the charm libs - except - redis, as redis has been updated to stop using stored state and instead use the data platform libs. An additional PR will be needed to update the redis relation to use the new lib,