### PR TITLE
Get hostname for Redis sentinel leader

### DIFF
--- a/src/relations/redis.py
+++ b/src/relations/redis.py
@@ -59,7 +59,9 @@ class Redis(framework.Object):
         relation = self.model.get_relation("redis")
         application_data = relation.data[relation.app] if relation else {}
 
-        redis_hostname = application_data.get("leader-host")
+        redis_hostname = application_data.get("leader-host") or unit_data.get(
+            "hostname"
+        )
         redis_port = unit_data.get("port")
         redis_relation = bool(unit_data)
         return redis_hostname, redis_port, redis_relation

--- a/src/relations/redis.py
+++ b/src/relations/redis.py
@@ -55,8 +55,11 @@ class Redis(framework.Object):
             redis_port: port of redis service
             redis_relation: bool for if redis has been related
         """
-        rel = self.charm.redis.relation_data or {}
-        redis_hostname = rel.get("hostname")
-        redis_port = rel.get("port")
-        redis_relation = bool(rel)
+        unit_data = self.charm.redis.relation_data or {}
+        relation = self.model.get_relation("redis")
+        application_data = relation.data[relation.app] if relation else {}
+
+        redis_hostname = application_data.get("leader-host")
+        redis_port = unit_data.get("port")
+        redis_relation = bool(unit_data)
         return redis_hostname, redis_port, redis_relation


### PR DESCRIPTION
An update has been made to the redis charm so that this now adds the `leader-host` ie. the host of the sentinel leader to the application databag. Please note this is not the same as adding it to the unit relation databag. 

This update uses this value as the redis host that Superset connects to, therefore making sure it is always connected to the sentinel leader and preventing errors we've seen with redis leadership changes where superset attempts to write to a read only replica.

In the case where superset is deployed with a revision of the redis charm < `35` which does not provide this then the `hostname` continues to be used.