### PR TITLE
update metadata with 3.1.3 image

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -19,9 +19,9 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.1/stable
+          juju-channel: 3.4/stable
           provider: microk8s
-          microk8s-addons: "ingress storage dns rbac registry"
-          channel: 1.25-strict/stable
+          microk8s-addons:  "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"
+          channel: 1.28-strict/stable
       - name: Run integration tests
         run: tox -e ${{ matrix.tox-environments }}

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -12,5 +12,5 @@ jobs:
     with:
       integration-test-provider: microk8s
       integration-test-provider-channel: 1.25-strict/stable
-      integration-test-juju-channel: 3.1/stable
+      integration-test-juju-channel: 3.4/stable
       integration-test-modules: '["test_charm"]'

--- a/config.yaml
+++ b/config.yaml
@@ -201,3 +201,7 @@ options:
     description: The time in seconds the server can maintain a database connection.
     default: 180
     type: int
+  cache-warmup:
+    description: Boolean representing if the cache warm-up functionality should be enabled.
+    default: False
+    type: boolean

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,7 +26,7 @@ resources:
   superset-image:
     type: oci-image
     description: OCI image for superset
-    upstream-source: ghcr.io/canonical/charmed-superset-rock:2.1.0-22.04-edge
+    upstream-source: ghcr.io/canonical/charmed-superset-rock:3.1.3-22.04-edge
 
 requires:
   nginx-route:

--- a/src/charm.py
+++ b/src/charm.py
@@ -353,6 +353,7 @@ class SupersetK8SCharm(TypedCharmBase[CharmConfig]):
             "WEBSERVER_TIMEOUT": self.config["webserver-timeout"],
             "STATSD_PORT": STATSD_PORT,
             "LOG_FILE": LOG_FILE,
+            "CACHE_WARMUP": self.config["cache-warmup"],
         }
         return env
 

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -43,6 +43,7 @@ class CharmConfig(BaseConfigModel):
     superset_secret_key: Optional[str]
     admin_password: str
     charm_function: FunctionType
+    cache_warmup: bool
     alerts_attach_reports: bool
     dashboard_cross_filters: bool
     dashboard_rbac: bool

--- a/templates/superset_config.py
+++ b/templates/superset_config.py
@@ -88,7 +88,8 @@ TALISMAN_CONFIG = {
         "worker-src": ["'self'", "blob:"],
         "connect-src": ["'self'", "https://api.mapbox.com", "https://events.mapbox.com"],
         "object-src": "'none'",
-     }
+     },
+     "session_cookie_secure": False,
 }
 
 SQLALCHEMY_POOL_SIZE = int(os.getenv("SQLALCHEMY_POOL_SIZE"))

--- a/templates/superset_config.py
+++ b/templates/superset_config.py
@@ -96,6 +96,26 @@ SQLALCHEMY_POOL_SIZE = int(os.getenv("SQLALCHEMY_POOL_SIZE"))
 SQLALCHEMY_POOL_TIMEOUT = int(os.getenv("SQLALCHEMY_POOL_TIMEOUT"))
 SQLALCHEMY_MAX_OVERFLOW = int(os.getenv("SQLALCHEMY_MAX_OVERFLOW"))
 
+beat_schedule_config = {
+        "reports.prune_log": {
+            "task": "reports.prune_log",
+            "schedule": crontab(minute=0, hour=0),
+        },
+    }
+
+if os.getenv("CACHE_WARMUP", "").lower() != "false":
+    beat_schedule_config.update({"cache-warmup-daily": {
+            "task": "cache-warmup",
+            "schedule": crontab(minute="1", hour="7"),  # UTC @daily
+            "kwargs": {
+                "strategy_name": "top_n_dashboards",
+                "top_n": 10,
+                "since": "7 days ago",
+            },
+        },
+    }
+    )
+
 # Celery cache warm-up
 class CeleryConfig(object):
     broker_url = (
@@ -116,21 +136,7 @@ class CeleryConfig(object):
             "rate_limit": "100/s",
         },
     }
-    beat_schedule = {
-        "reports.prune_log": {
-            "task": "reports.prune_log",
-            "schedule": crontab(minute=0, hour=0),
-        },
-        "cache-warmup-daily": {
-            "task": "cache-warmup",
-            "schedule": crontab(minute="1", hour="7"),  # UTC @daily
-            "kwargs": {
-                "strategy_name": "top_n_dashboards",
-                "top_n": 10,
-                "since": "7 days ago",
-            },
-        },
-    }
+    beat_schedule = beat_schedule_config
 
 
 CELERY_CONFIG = CeleryConfig

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -167,7 +167,7 @@ async def api_authentication(ops_test, base_url):
 
 
 async def get_chart_count(ops_test: OpsTest, url, session):
-    """Count number of Superset charts.
+    """Count Superset charts.
 
     Args:
         ops_test: PyTest object.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -125,12 +125,12 @@ async def restart_application(ops_test: OpsTest):
     await action.wait()
 
 
-async def api_authentication(ops_test, base):
+async def api_authentication(ops_test, base_url):
     """Authenticate with the Superset API and set session tokens.
 
     Args:
         ops_test: PyTest object.
-        base: Base Superset URL.
+        base_url: Superset URL.
 
     Returns:
         session: The Requests session.
@@ -139,7 +139,7 @@ async def api_authentication(ops_test, base):
 
     # Get access token
     auth_response = session.post(
-        base + "/api/v1/security/login", json=API_AUTH_PAYLOAD, timeout=30
+        base_url + "/api/v1/security/login", json=API_AUTH_PAYLOAD, timeout=30
     )
     access_token = auth_response.json().get("access_token")
 
@@ -152,7 +152,7 @@ async def api_authentication(ops_test, base):
     )
 
     # Get CSRF token
-    csrf_url = f"{base}/api/v1/security/csrf_token/"
+    csrf_url = f"{base_url}/api/v1/security/csrf_token/"
     csrf_response = session.get(csrf_url)
     csrf_response.raise_for_status()
     csrf_token = csrf_response.json().get("result")
@@ -166,34 +166,32 @@ async def api_authentication(ops_test, base):
     return session
 
 
-async def get_chart_count(ops_test, base, session):
+async def get_chart_count(ops_test: OpsTest, url, session):
     """Count number of Superset charts.
 
     Args:
         ops_test: PyTest object.
-        base: Superset base URL.
+        url: Superset URL.
         session: Request session with headers.
 
     Returns:
-        The count of Superset charts.
+        Count of Superset charts.
     """
-    chart_response = session.get(base + "/api/v1/chart/", timeout=30)
+    chart_response = session.get(url + "/api/v1/chart/", timeout=30)
     charts = chart_response.json()
     return charts["count"]
 
 
-async def delete_chart(ops_test, base, session):
+async def delete_chart(ops_test: OpsTest, url, session):
     """Delete chart example chart `13`.
 
     Args:
         ops_test: PyTest object.
-        base: Superset base URL.
+        url: Superset URL.
         session: Request session with headers.
     """
-    url = f"{base}/api/v1/chart/13"
-
     try:
-        response = session.delete(url)
+        response = session.delete(url + "/api/v1/chart/13", timeout=30)
     except Exception as e:
         logger.error(f"Error deleting chart caused by: {e}")
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -11,8 +11,8 @@ import requests
 from conftest import deploy  # noqa: F401, pylint: disable=W0611
 from helpers import (
     UI_NAME,
+    api_authentication,
     delete_chart,
-    get_access_token,
     get_chart_count,
     get_unit_url,
     restart_application,
@@ -47,11 +47,11 @@ class TestDeployment:
         url = await get_unit_url(
             ops_test, application=UI_NAME, unit=0, port=8088
         )
-        headers = await get_access_token(ops_test, url)
+        session = await api_authentication(ops_test, url)
 
         # Delete a chart
-        original_charts = await get_chart_count(ops_test, url, headers)
-        await delete_chart(ops_test, url, headers)
+        original_charts = await get_chart_count(ops_test, url, session)
+        await delete_chart(ops_test, url, session)
 
         await simulate_crash(ops_test)
 
@@ -59,7 +59,8 @@ class TestDeployment:
         url = await get_unit_url(
             ops_test, application=UI_NAME, unit=0, port=8088
         )
-        chart_count = await get_chart_count(ops_test, url, headers)
+        session = await api_authentication(ops_test, url)
+        chart_count = await get_chart_count(ops_test, url, session)
 
         # Validate chart remains deleted
         logger.info("Validating state remains unchanged")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -128,6 +128,7 @@ class TestCharm(TestCase):
                         "WEBSERVER_TIMEOUT": 180,
                         "STATSD_PORT": 9125,
                         "LOG_FILE": "/var/log/superset.log",
+                        "CACHE_WARMUP": False,
                     },
                     "on-check-failure": {"up": "ignore"},
                 }
@@ -225,6 +226,7 @@ class TestCharm(TestCase):
                         "WEBSERVER_TIMEOUT": 180,
                         "STATSD_PORT": 9125,
                         "LOG_FILE": "/var/log/superset.log",
+                        "CACHE_WARMUP": False,
                     },
                     "on-check-failure": {"up": "ignore"},
                 },

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ passenv =
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.1.0.1
+    juju==3.5.2.0
     pytest==7.4.0
     pytest-asyncio==0.21
     pytest-operator==0.29.0
@@ -41,7 +41,7 @@ commands =
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.1.0.1
+    juju==3.5.2.0
     pytest==7.4.0
     pytest-asyncio==0.21
     pytest-operator==0.29.0
@@ -55,7 +55,7 @@ commands =
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.1.0.1
+    juju==3.5.2.0
     pytest==7.4.0
     pytest-asyncio==0.21
     pytest-operator==0.29.0
@@ -69,7 +69,7 @@ commands =
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.1.0.1
+    juju==3.5.2.0
     pytest==7.4.0
     pytest-asyncio==0.21
     pytest-operator==0.29.0


### PR DESCRIPTION
Updates the metadata to use the 3.1.3 image, this will be used for integration testing. Update was also required to the `TALISMAN_CONFIG` and the `charm` integration test as the mechanism for authentication with the API was updated in this version. It now requires the `CSRF` token be included in the request. 