### PR TITLE
Makes tls secret name config optional

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -131,7 +131,7 @@ class SupersetK8SCharm(TypedCharmBase[CharmConfig]):
             service_hostname=self.external_hostname,
             service_name=self.app.name,
             service_port=APPLICATION_PORT,
-            tls_secret_name=self.config["tls-secret-name"],
+            tls_secret_name=self.config["tls-secret-name"] or "",
             backend_protocol="HTTP",
         )
 

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -39,7 +39,7 @@ class CharmConfig(BaseConfigModel):
 
     allow_image_domains: Optional[str]
     external_hostname: str
-    tls_secret_name: str
+    tls_secret_name: Optional[str]
     superset_secret_key: Optional[str]
     admin_password: str
     charm_function: FunctionType


### PR DESCRIPTION
In order to use the https-lego-operator charm the tls-secret-name needs to be unset, this PR makes this value optional.