### PR TITLE
add index table to documentation

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -14,6 +14,30 @@ It is intended for data practitioners who require advanced visualisation without
 | Reference </br> **Technical information**, including [supported feature flags](https://discourse.charmhub.io/t/supported-feature-flags/15647) and [version compatibility](https://discourse.charmhub.io/t/compatible-charm-revisions-and-resources/15648)                                                                              | 
 
 
+
+# Navigation
+
+| Level | Path                | Navlink                                                                                                                                   |
+| ----- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | tutorial            | [Tutorial]()                                                                                                                              |
+| 2     | t-introduction      | [1. Get started](https://discourse.charmhub.io/t/get-started-with-charmed-superset/15641)                                                 |
+| 2     | t-setup-environment | [2. Environment setup](https://discourse.charmhub.io/t/set-up-your-environment/15642)                                                     |
+| 2     | t-deploy-relations  | [3. Deploy supporting charms](https://discourse.charmhub.io/t/deploy-supporting-charms/15643)                                             |
+| 2     | t-deploy-superset   | [4. Deploy Charmed Superset](https://discourse.charmhub.io/t/deploy-charmed-superset/15644)                                               |
+| 2     | t-create-dashboard  | [5. Create a dashboard](https://discourse.charmhub.io/t/create-a-dashboard/15645)                                                         |
+| 2     | t-cleanup           | [6. Clean up](https://discourse.charmhub.io/t/topic/15646)                                                                                |
+| 1     | how-to              | [How to]()                                                                                                                                |
+| 2     | h-performance       | [Performance](https://discourse.charmhub.io/t/optimise-your-deployment-performance/15651)                                                 |
+| 2     | h-security          | [Security](https://discourse.charmhub.io/t/enable-security-features/15649)                                                                |
+| 2     | h-observability     | [Observability](https://discourse.charmhub.io/t/integrate-with-canonical-observability-stack/15650)                                       |
+| 1     | reference           | [Reference]()                                                                                                                             |
+| 2     | r-feature-flags     | [Feature flags](https://discourse.charmhub.io/t/supported-feature-flags/15647)                                                            |
+| 2     | r-compatibility     | [Version compatibility](https://discourse.charmhub.io/t/compatible-charm-revisions-and-resources/15648)                                   |
+
+# Redirects
+
+[details=Mapping table] | Path | Location | | ---- | -------- | [/details]
+
 ## Project and Community
 
 Charmed Superset is a member of the Ubuntu family. It’s an open source


### PR DESCRIPTION
Add the documentation mapping table to the index required for displaying docs directly on the charmhub homepage.