### PR TITLE
CSS-14004: update dashboard and add alerts

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -37,7 +37,7 @@ requires:
   redis:
     interface: redis
     limit: 1
-  log-proxy:
+  logging:
     interface: loki_push_api
     optional: true
     limit: 1

--- a/src/grafana_dashboards/superset-monitoring.json.tmpl
+++ b/src/grafana_dashboards/superset-monitoring.json.tmpl
@@ -18,10 +18,22 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 9,
   "links": [],
   "liveNow": false,
   "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Metrics",
+      "type": "row"
+    },
     {
       "datasource": {
         "type": "prometheus",
@@ -50,10 +62,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 0,
-        "y": 0
+        "y": 1
       },
       "id": 8,
       "options": {
@@ -118,10 +130,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 4,
-        "y": 0
+        "y": 1
       },
       "id": 12,
       "options": {
@@ -186,10 +198,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 8,
-        "y": 0
+        "y": 1
       },
       "id": 10,
       "options": {
@@ -254,10 +266,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 12,
-        "y": 0
+        "y": 1
       },
       "id": 11,
       "options": {
@@ -323,7 +335,7 @@
                   "icon": "img/icons/unicons/arrow-up.svg",
                   "index": 0
                 },
-                "to": null
+                "to": 100
               },
               "type": "range"
             },
@@ -352,10 +364,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 16,
-        "y": 0
+        "y": 1
       },
       "id": 13,
       "options": {
@@ -363,6 +375,9 @@
           "background": {
             "color": {
               "fixed": "transparent"
+            },
+            "image": {
+              "mode": "fixed"
             }
           },
           "border": {
@@ -372,6 +387,7 @@
           },
           "config": {
             "fill": {
+              "field": "Value",
               "fixed": "green"
             },
             "path": {
@@ -386,10 +402,10 @@
           },
           "name": "Element 1713352648460",
           "placement": {
-            "height": 110,
+            "height": 72,
             "left": 0,
             "top": 0,
-            "width": 329
+            "width": 306
           }
         }
       },
@@ -413,6 +429,112 @@
       "title": "Is Superset up?",
       "transformations": [],
       "type": "icon"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "-1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "/"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "9.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum(max(celery_worker_up) by (hostname))",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "count(max(celery_worker_up) by (hostname))",
+          "format": "table",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "-1",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Workers",
+      "transformations": [],
+      "type": "stat"
     },
     {
       "datasource": {
@@ -472,7 +594,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 24,
         "x": 0,
         "y": 4
@@ -567,7 +689,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 12
+        "y": 10
       },
       "id": 4,
       "options": {
@@ -671,7 +793,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 12
+        "y": 10
       },
       "id": 14,
       "options": {
@@ -775,7 +897,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 16
       },
       "id": 5,
       "options": {
@@ -829,19 +951,151 @@
       ],
       "title": "SQLlabs",
       "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 16,
+      "panels": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P0DC3F85ACCA0B4BD"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 2
+          },
+          "id": 17,
+          "options": {
+            "dedupStrategy": "exact",
+            "enableLogDetails": true,
+            "prettifyLogMessage": false,
+            "showCommonLabels": false,
+            "showLabels": false,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": true
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "P0DC3F85ACCA0B4BD"
+              },
+              "editorMode": "code",
+              "expr": "{juju_application=~\".*superset.*ui.*\", juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"} |= ``",
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "title": "UI logs",
+          "type": "logs"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P0DC3F85ACCA0B4BD"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 18,
+          "options": {
+            "dedupStrategy": "exact",
+            "enableLogDetails": true,
+            "prettifyLogMessage": false,
+            "showCommonLabels": false,
+            "showLabels": false,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": true
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "P0DC3F85ACCA0B4BD"
+              },
+              "editorMode": "code",
+              "expr": "{juju_application=~\".*superset.*worker.*\", juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"} |= ``",
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "title": "Worker logs ",
+          "type": "logs"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P0DC3F85ACCA0B4BD"
+          },
+          "description": "",
+          "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 16
+          },
+          "id": 19,
+          "options": {
+            "dedupStrategy": "exact",
+            "enableLogDetails": true,
+            "prettifyLogMessage": false,
+            "showCommonLabels": false,
+            "showLabels": false,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": true
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "P0DC3F85ACCA0B4BD"
+              },
+              "editorMode": "code",
+              "expr": "{juju_application=~\".*superset.*beat.*\", juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"} |= ``",
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "title": "Beat logs ",
+          "type": "logs"
+        }
+      ],
+      "title": "Logs",
+      "type": "row"
     }
   ],
-  "refresh": "",
+  "refresh": "5s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "charm: superset-k8s"
+  ],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "hide": 0,
         "includeAll": true,
@@ -857,9 +1111,13 @@
       },
       {
         "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "hide": 0,
         "includeAll": true,
@@ -868,6 +1126,7 @@
         "name": "prometheusds",
         "options": [],
         "query": "prometheus",
+        "queryValue": "",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -876,9 +1135,13 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": {
           "uid": "${prometheusds}"
@@ -907,9 +1170,13 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": {
           "uid": "${prometheusds}"
@@ -938,9 +1205,13 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": {
           "uid": "${prometheusds}"
@@ -969,9 +1240,13 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": {
           "uid": "${prometheusds}"
@@ -1006,7 +1281,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "Superset Metrics",
-  "uid": "cc216658-9f09-4b73-81d7-16c99c54ca51",
+  "uid": "00112546513c0282bb384c67dea4c9c10259fabc",
   "version": 1,
   "weekStart": ""
 }

--- a/src/prometheus_alert_rules/superset_rules.yaml
+++ b/src/prometheus_alert_rules/superset_rules.yaml
@@ -1,0 +1,37 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Learn more at: https://juju.is/docs/sdk
+
+groups:
+
+- name: superset_k8s
+
+  rules:
+    - alert: SupersetDown
+      expr: 'sum(rate(superset_welcome[2m])) == 0'
+      for: 2m
+      labels:
+        severity: critical
+      annotations:
+        summary: All Superset instances are down
+        description: "All Superset instances are down\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+  
+      
+    - alert: SupersetHalfOrMoreDown
+      expr: '(sum(rate(superset_welcome[2m])) / clamp_min(count(superset_welcome) * max(rate(superset_welcome[2m])), 1/1000)) <= 0.5'
+      for: 2m
+      labels:
+        severity: high
+      annotations:
+        summary: Half or more of Superset instances are down
+        description: "Half or more of Superset instances are down\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+    - alert: WorkersDown
+      expr: 'sum(max(celery_worker_up) by (hostname)) == 0'
+      for: 2m
+      labels:
+        severity: critical
+      annotations:
+        summary: All Superset workers are down
+        description: "All Superset workers are down\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"


### PR DESCRIPTION
This PR:
- slightly updates the dashboard
  - fixes a few small issues with the current dashboard
  - adds a panel with the running workers*
- adds alters for both superset-ui and workers
- adds the celery exporter as the metrics service for workers
- renames the logging endpoint to be similar to other charms (useful for the updated terraform plans) 


* i wanted to add more things, but given the circumstances i cut some corners. Basically, the workers can be configured to report more metrics to redis (which are then read by the celery-exporter).

![image](https://github.com/user-attachments/assets/613176a2-18a3-4e3b-bbd6-af76f46bcb73)
