### PR TITLE
CSS-15821 Add config option for dashboard size limit

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -165,3 +165,7 @@ options:
   smtp-secret-id:
     description: ID of the Juju secret for the SMTP credentials used to send emails.
     type: string
+  dashboard-size-limit:
+    description: Integer representing how many characters to allow in a dashboard definition.
+    default: 65535
+    type: int

--- a/src/charm.py
+++ b/src/charm.py
@@ -408,6 +408,7 @@ class SupersetK8SCharm(TypedCharmBase[CharmConfig]):
             "LOG_FILE": LOG_FILE,
             "CACHE_WARMUP": self.config["cache-warmup"],
             "REDIS_TIMEOUT": self.config["redis-timeout"],
+            "DASHBOARD_SIZE_LIMIT": self.config["dashboard-size-limit"],
         }
         if self.config["feature-flags"]:
             env.update(self.config["feature-flags"])

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -72,6 +72,7 @@ class CharmConfig(BaseConfigModel):
     feature_flags: Optional[str]
     redis_timeout: int
     smtp_secret_id: Optional[str]
+    dashboard_size_limit: int
 
     @validator("*", pre=True)
     @classmethod

--- a/templates/superset_config.py
+++ b/templates/superset_config.py
@@ -297,6 +297,10 @@ if all(os.getenv(var) for var in required_auth_vars):
     # For Google https redirect
     ENABLE_PROXY_FIX = True
 
+# Dashboard size limitation
+SUPERSET_DASHBOARD_POSITION_DATA_LIMIT = int(os.getenv("DASHBOARD_SIZE_LIMIT", 65535))
+
+# Proxy
 HTTP_PROXY = os.getenv("HTTP_PROXY")
 HTTPS_PROXY = os.getenv("HTTPS_PROXY")
 NO_PROXY = os.getenv("NO_PROXY")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -121,6 +121,7 @@ class TestCharm(TestCase):
                         "STATSD_PORT": 9125,
                         "LOG_FILE": "/var/log/superset.log",
                         "CACHE_WARMUP": False,
+                        "DASHBOARD_SIZE_LIMIT": 65535,
                     },
                     "on-check-failure": {"up": "ignore"},
                 }
@@ -214,6 +215,7 @@ class TestCharm(TestCase):
                         "STATSD_PORT": 9125,
                         "LOG_FILE": "/var/log/superset.log",
                         "CACHE_WARMUP": False,
+                        "DASHBOARD_SIZE_LIMIT": 65535,
                     },
                     "on-check-failure": {"up": "ignore"},
                 },


### PR DESCRIPTION
# Description

Addresses [CSS-15821](https://warthogs.atlassian.net/browse/CSS-15821).

Adds an option for dashboard size limit in characters as described [here](https://github.com/apache/superset/discussions/13629).