### PR TITLE
[CSS-17035] Publish charm for both main and track

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -1,13 +1,12 @@
-name: Publish to edge
+name: Publish Charm
 
 on:
   push:
     branches:
       - main
+      - track/*
 
 jobs:
   publish:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
     secrets: inherit
-    with:
-      channel: latest/edge


### PR DESCRIPTION
The Superset charm uses [canonical/operator-workflows](https://github.com/canonical/operator-workflows/tree/98baa32e7f36068e9ab6d7de14a81e2243430a4a?tab=readme-ov-file#publish-charm-workflow-canonicaloperator-workflowsgithubworkflowspublish_charmyamlmain),

which under the hood uses [https://github.com/canonical/charming-actions/tree/main/channel](https://github.com/canonical/charming-actions/tree/main/channel).

The only change needed for the action to recognize which Charmhub channel to publish to is to remove the explicit name and trigger on pushes to any `track` branch.
