### PR TITLE
CSS-17035 Update promotion

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -4,17 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       origin-channel:
-        type: choice
-        description: 'Origin Channel'
-        options:
-        - latest/edge
+        description: 'Origin Channel e.g. latest/edge'
+        required: true
       destination-channel:
-        type: choice
-        description: 'Destination Channel'
-        options:
-        - latest/stable
-    secrets:
-      CHARMHUB_TOKEN:
+        description: 'Destination Channel e.g. 6/beta'
         required: true
 
 jobs:
@@ -23,4 +16,5 @@ jobs:
     with:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}
-    secrets: inherit
+    secrets:
+      CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}


### PR DESCRIPTION
Allow free text for dispatch on promotion.

Secrets token is invalid in workflow dispatch, it must be in jobs section