### PR TITLE
CSS-17046 fix deps for tox lint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -129,13 +129,13 @@ deps =
     pytest
     black==22.8.0
     codespell==2.2.1
-    flake8==5.0.4
-    flake8-builtins==1.5.3
-    flake8-copyright==0.2.3
-    flake8-docstrings==1.6.0
+    flake8==7.0.0
+    flake8-builtins==3.0.0
+    flake8-copyright==0.2.4
+    flake8-docstrings==1.7.0
     isort==5.10.1
     pep8-naming==0.13.2
-    pyproject-flake8==5.0.4.post1
+    pyproject-flake8==7.0.0
     flake8-docstrings-complete>=1.0.3
     flake8-test-docs>=1.0
 commands =


### PR DESCRIPTION
just too old flake which is incompatible with the latest python. And python we got from the new ubuntu base