### PR TITLE
fix: check leader on relation created in trino-catalog lib

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@fix_integration_test
     secrets: inherit
     with:
       test-timeout: 90

--- a/lib/charms/trino_k8s/v0/trino_catalog.py
+++ b/lib/charms/trino_k8s/v0/trino_catalog.py
@@ -23,7 +23,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 
@@ -231,6 +231,8 @@ class TrinoCatalogRequirer(Object):
 
     def _on_relation_created(self, event) -> None:
         """Publish app name so the provider can build a readable username."""
+        if not self.charm.unit.is_leader():
+            return
         event.relation.data[self.charm.app]["app_name"] = self.charm.app.name
 
     def get_trino_info(self) -> Optional[dict]:

--- a/src/relations/trino_catalog.py
+++ b/src/relations/trino_catalog.py
@@ -380,11 +380,15 @@ class TrinoCatalogRelationHandler(ops.Object):
             force_update: Whether to force update all connections.
         """
         for conn in connections:
+            uri_user = f"trino://{quote_plus(username)}"
+            has_current_user = (
+                f"{uri_user}:" in conn.sqlalchemy_uri  # user:password@host
+                or f"{uri_user}@" in conn.sqlalchemy_uri  # user@host
+            )
             needs_update = (
                 force_update
                 or f"@{trino_url}/" not in conn.sqlalchemy_uri
-                or f"trino://{quote_plus(username)}@"
-                not in conn.sqlalchemy_uri
+                or not has_current_user
             )
 
             if not needs_update:


### PR DESCRIPTION
This PR introduces a fix in the trino-catalog library. The issue was encountered in staging where the Superset UI app has multiple units and is related to Trino through this library. The non-leader units failed upon relation-created since only the leader is able to write to the databag.

The PR also fixes the check used to compare connection strings to avoid superfluous "Updating Superset database..." logs when there is nothing to update.  