### PR TITLE
Update the permissions for the publish and promote actions

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -18,4 +18,4 @@ jobs:
       destination-channel: ${{ github.event.inputs.destination-channel }}
     secrets: inherit
     permissions:
-      contents: read
+      contents: write

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -14,4 +14,4 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
     secrets: inherit
     permissions:
-      contents: read
+      contents: write


### PR DESCRIPTION
## Description
Publish and promote charm actions have recently been failing due to an [organization-level policy update](https://discourse.canonical.com/t/upcoming-change-to-github-actions-settings/7286). This PR sets the correct permision level to overcome the issue. 


## Engineering checklist
_Check only items that apply_

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Independent change*

 _* This is an independent change if it can be merged and released independently without any related service deployments._

## Merging instructions

The preferred way of merging:
- [ ] Merge
- [ ] Squash and Merge
- [ ] Rebase and Merge

## Test instructions

_(optional)_ Describe any non-standard test instructions and configuration settings. Delete this section if not applicable.

## Notes for code reviewers

_(optional)_ Mention any relevant information for code reviewers. Delete this section if not applicable.
