### PR TITLE
feat: rewrite trino permission error msg

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -177,3 +177,9 @@ options:
   max-form-parts:
     description: Werkzeug limit for the number of parts to allow in a multipart form.
     type: int
+  data-access-request-url:
+    description: |
+      URL users are directed to when they hit a Trino/Ranger permission-denied error
+      while viewing a dashboard, so they can request access to the restricted data.
+      When unset, the message tells users to contact their administrator instead.
+    type: string

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -433,6 +433,11 @@ from typing import (
     overload,
 )
 
+try:
+    from cryptography.fernet import Fernet, InvalidToken
+except ImportError:
+    Fernet = None
+    InvalidToken = None
 from ops import JujuVersion, Model, Secret, SecretInfo, SecretNotFoundError
 from ops.charm import (
     CharmBase,
@@ -453,7 +458,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 58
+LIBPATCH = 59
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -488,6 +493,10 @@ MODEL_ERRORS = {
     "no_label_and_uri": "ERROR either URI or label should be used for getting an owned secret but not both",
     "owner_no_refresh": "ERROR secret owner cannot use --refresh",
 }
+
+CROSS_MODEL_RELATION_CONSUMER_SECRETS = [
+    "mtls-cert",
+]
 
 
 ##############################################################################
@@ -1227,6 +1236,15 @@ class Data(ABC):
         """Load secrets from the databag."""
         raise NotImplementedError
 
+    def _get_encryption_key(self, relation: Relation) -> Optional[str]:
+        """Fetch the encryption key from the encryption secret if available."""
+        if not (encryption_secret := relation.data[relation.app].get("encryption-secret")):
+            return None
+
+        # get the encryption secret created on provider side
+        secret = self._model.get_secret(id=encryption_secret)
+        return secret.get_content().get("encryption-key")
+
     def _fetch_specific_relation_data(
         self, relation: Relation, fields: Optional[List[str]]
     ) -> Dict[str, str]:
@@ -1586,11 +1604,48 @@ class Data(ABC):
             return {}
 
         if fields:
-            return {
+            relation_data = {
                 k: relation.data[component][k] for k in fields if k in relation.data[component]
             }
         else:
-            return dict(relation.data[component])
+            relation_data = dict(relation.data[component])
+
+        try:
+            remote_model_uuid = relation.remote_model.uuid
+        except (FileNotFoundError, ModelError, RuntimeError) as e:
+            # access to remote model added in Juju 3.6.2, fails with 2.9
+            logger.warning("Access to remote model failed: %s", e)
+            remote_model_uuid = ""
+
+        # if not a cross-model relation we can return data as-is
+        if remote_model_uuid == "" or self._model.uuid == remote_model_uuid:
+            return relation_data
+
+        if not (encryption_key := self._get_encryption_key(relation)):
+            return relation_data
+
+        if not Fernet:
+            logger.warning(
+                "Cryptography module not installed. Could not decrypt sensitive field in cross-model relation"
+            )
+            return relation_data
+
+        # still here means sensitive data needs to be decrypted
+        for key, value in relation_data.items():
+            if key in CROSS_MODEL_RELATION_CONSUMER_SECRETS:
+                try:
+                    f = Fernet(encryption_key)
+                    decrypted_value = f.decrypt(value.encode()).decode()
+                    relation_data[key] = decrypted_value
+                except (
+                    AttributeError,
+                    InvalidToken,
+                    TypeError,
+                    ValueError,
+                ):  # pyright: ignore [reportGeneralTypeIssues]
+                    logger.warning("Could not decrypt sensitive field in cross-model relation")
+
+        return relation_data
 
     def _fetch_relation_data_with_secrets(
         self,
@@ -1637,8 +1692,40 @@ class Data(ABC):
         if component not in relation.data or relation.data[component] is None:
             return
 
-        if relation:
-            relation.data[component].update(data)
+        if not relation:
+            return
+
+        # ensure no sensitive information is stored in relation data
+        encryption_key = self._get_encryption_key(relation)
+
+        try:
+            remote_model_uuid = relation.remote_model.uuid
+        except (FileNotFoundError, ModelError, RuntimeError):
+            # access to remote model added in Juju 3.6.2, fails with 2.9
+            remote_model_uuid = ""
+
+        if encryption_key and remote_model_uuid != "" and self._model.uuid != remote_model_uuid:
+            for key, value in data.items():
+                try:
+                    f = Fernet(encryption_key)  # pyright: ignore [reportOptionalCall]
+                    if key in CROSS_MODEL_RELATION_CONSUMER_SECRETS:
+                        encrypted_value = f.encrypt(value.encode()).decode()
+                        data[key] = encrypted_value
+                except (
+                    AttributeError,
+                    InvalidToken,
+                    ValueError,
+                ):  # pyright: ignore [reportGeneralTypeIssues]
+                    logger.warning("Could not encrypt sensitive field in cross-model relation")
+                    data[key] = ""
+                except TypeError:
+                    # "TypeError: 'NoneType' object is not callable" raised when Fernet is `None`
+                    logger.warning(
+                        "Cryptography module not installed. Could not decrypt sensitive field in cross-model relation"
+                    )
+                    data[key] = ""
+
+        relation.data[component].update(data)
 
     def _delete_relation_data_without_secrets(
         self, component: Union[Application, Unit], relation: Relation, fields: List[str]
@@ -1899,7 +1986,7 @@ class ProviderData(Data):
         """Set values for fields not caring whether it's a secret or not."""
         keys = set(data.keys())
         if self.fetch_relation_field(relation.id, self.RESOURCE_FIELD) is None and (
-            keys - {"endpoints", "read-only-endpoints", "replset"}
+            keys - {"endpoints", "read-only-endpoints", "replset", "encryption-secret"}
         ):
             raise PrematureDataAccessError(
                 "Premature access to relation data, update is forbidden before the connection is initialized."
@@ -2112,12 +2199,31 @@ class RequirerData(Data):
             field
             for field in self.SECRET_LABEL_MAP.keys()
             if field not in self._remote_secret_fields
+            and not (
+                field in CROSS_MODEL_RELATION_CONSUMER_SECRETS and self.is_cross_model_relation
+            )
         ]
         if additional_secret_fields:
             self._remote_secret_fields += additional_secret_fields
         self.data_component = self.local_unit
 
     # Internal functions
+    @property
+    def is_cross_model_relation(self) -> bool:
+        """Determines whether the relation is a cross-model relation or not."""
+        if len(self.relations) == 0:
+            return False
+
+        try:
+            remote_model_uuid = self.relations[0].remote_model.uuid
+        except (FileNotFoundError, ModelError, RuntimeError):
+            # access to remote model added in Juju 3.6.2, fails with 2.9
+            return False
+
+        if self._model.uuid != remote_model_uuid:
+            return True
+
+        return False
 
     def _is_resource_created_for_relation(self, relation: Relation) -> bool:
         if not relation.app:
@@ -2389,6 +2495,44 @@ class ProviderEventHandlers(EventHandlers):
                 raise ValueError(f"Cannot change {key} after relation has already been created")
 
     # Event handlers
+    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
+        """Event emitted when a relation is created."""
+        if not self.relation_data.local_unit.is_leader():
+            return
+
+        try:
+            remote_model_uuid = event.relation.remote_model.uuid
+        except (FileNotFoundError, ModelError, RuntimeError):
+            # access to remote model added in Juju 3.6.2, fails with 2.9
+            return
+
+        if self.model.uuid == remote_model_uuid:
+            return
+
+        if not Fernet:
+            logger.warning(
+                "Cryptography module not installed. Could not decrypt sensitive field in cross-model relation"
+            )
+            return
+
+        # in cross-model relations, generate an encryption key and share it with the requirer as a secret
+        event_data = {}
+        secret_label = f"{self.model.uuid}-{event.relation.id}-encryption-secret"
+
+        try:
+            # check if secret was already created to avoid duplicates
+            secret = self.charm.model.get_secret(label=secret_label)
+        except SecretNotFoundError:
+            encryption_key = Fernet.generate_key()  # pyright: ignore [reportOptionalMemberAccess]
+            content = {"encryption-key": encryption_key.decode()}
+            secret = self.charm.app.add_secret(content, label=secret_label)
+
+        secret.grant(event.relation)
+        if not secret.id:
+            raise SecretError("Encryption secret is missing secred id")
+        event_data["encryption-secret"] = secret.id
+
+        self.relation_data.update_relation_data(event.relation.id, event_data)
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the relation data has changed."""
@@ -4412,6 +4556,33 @@ class KafkaRequirerEventHandlers(RequirerEventHandlers):
         # Check which data has changed to emit customs events.
         diff = self._diff(event)
 
+        # send request again if encryption secret was added from provider side
+        if "encryption-secret" in diff.added and self.relation_data.local_unit.is_leader():
+            relation_data = {
+                "topic": self.relation_data.topic,
+                "encryption-secret": event.relation.data[event.relation.app].get(
+                    "encryption-secret"
+                ),
+            }
+
+            if self.relation_data.mtls_cert:
+                relation_data["mtls-cert"] = self.relation_data.mtls_cert
+
+            if self.relation_data.consumer_group_prefix:
+                relation_data["consumer-group-prefix"] = self.relation_data.consumer_group_prefix
+
+            if self.relation_data.extra_user_roles:
+                relation_data["extra-user-roles"] = self.relation_data.extra_user_roles
+            if self.relation_data.extra_group_roles:
+                relation_data["extra-group-roles"] = self.relation_data.extra_group_roles
+            if self.relation_data.entity_type:
+                relation_data["entity-type"] = self.relation_data.entity_type
+            if self.relation_data.entity_permissions:
+                relation_data["entity-permissions"] = self.relation_data.entity_permissions
+
+            self.relation_data.update_relation_data(event.relation.id, relation_data)
+            return
+
         # Check if the topic is created
         # (the Kafka charm shared the credentials).
 
@@ -5689,6 +5860,24 @@ class EtcdRequirerEventHandlers(RequirerEventHandlers):
 
         # Check which data has changed to emit customs events.
         diff = self._diff(event)
+
+        # send request again if encryption secret was added from provider side
+        if "encryption-secret" in diff.added and self.relation_data.local_unit.is_leader():
+            payload = {
+                "prefix": self.relation_data.prefix,
+                "encryption-secret": event.relation.data[event.relation.app].get(
+                    "encryption-secret"
+                ),
+            }
+            if self.relation_data.mtls_cert:
+                payload["mtls-cert"] = self.relation_data.mtls_cert
+
+            self.relation_data.update_relation_data(
+                event.relation.id,
+                payload,
+            )
+            return
+
         # Register all new secrets with their labels
         if any(newval for newval in diff.added if self.relation_data._is_secret_field(newval)):
             self.relation_data._register_secrets_to_relation(event.relation, diff.added)

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -361,7 +361,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 60
+LIBPATCH = 61
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -1822,6 +1822,7 @@ class PrometheusRulesProvider(Object):
             events.relation_changed,
             self._charm.on.leader_elected,
             self._charm.on.upgrade_charm,
+            self._charm.on.config_changed,
         ]
 
         for event_source in event_sources:

--- a/src/charm.py
+++ b/src/charm.py
@@ -461,6 +461,7 @@ class SupersetK8SCharm(TypedCharmBase[CharmConfig]):
             "MAX_CONTENT_LENGTH": self.config["max-content-length"],
             "MAX_FORM_MEMORY_SIZE": self.config["max-form-memory-size"],
             "MAX_FORM_PARTS": self.config["max-form-parts"],
+            "DATA_ACCESS_REQUEST_URL": self.config["data-access-request-url"],
         }
         if self.config["feature-flags"]:
             env.update(self.config["feature-flags"])

--- a/src/literals.py
+++ b/src/literals.py
@@ -16,6 +16,7 @@ CONFIG_FILES = [
     "superset_config.py",
     "custom_sso_security_manager.py",
     "sentry_interceptor.py",
+    "permission_error_messages.py",
 ]
 CONFIG_PATH = "/app/pythonpath"
 UI_FUNCTIONS = ["app", "app-gunicorn"]

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -79,6 +79,7 @@ class CharmConfig(BaseConfigModel):
     max_content_length: Optional[int]
     max_form_memory_size: Optional[int]
     max_form_parts: Optional[int]
+    data_access_request_url: Optional[str]
 
     @validator("*", pre=True)
     @classmethod

--- a/templates/custom_sso_security_manager.py
+++ b/templates/custom_sso_security_manager.py
@@ -1,7 +1,31 @@
+from flask_appbuilder.models.sqla.filters import FilterContains
+from flask_appbuilder.security.sqla.apis import PermissionViewMenuApi
 from superset.security import SupersetSecurityManager
 
 
+class _SupersetPermissionViewMenuApi(PermissionViewMenuApi):
+    """Workaround for https://github.com/apache/superset/issues/40293.
+
+    Flask-AppBuilder's PermissionViewMenuApi does not declare search_columns,
+    so every filter query to /api/v1/security/permissions-resources/ fails with
+    "Filter column: id not allowed to filter". Declaring them here and
+    registering the RelationshipToManyFilter handlers for the dot-path columns
+    restores filtering for the List Roles UI and for any direct API consumer.
+    """
+
+    search_columns = ["id", "permission.name", "view_menu.name"]
+
+    def _init_properties(self) -> None:
+        super()._init_properties()
+        for col in ["permission.name", "view_menu.name"]:
+            self._filters._search_filters[col] = [
+                FilterContains(col, self.datamodel)
+            ]
+
+
 class CustomSsoSecurityManager(SupersetSecurityManager):
+    permission_view_menu_api = _SupersetPermissionViewMenuApi
+
     def oauth_user_info(self, provider, response=None):
         if provider == "google":
             me = self.appbuilder.sm.oauth_remotes[provider].get(

--- a/templates/permission_error_messages.py
+++ b/templates/permission_error_messages.py
@@ -1,0 +1,161 @@
+"""Rewrite Trino/Ranger permission-denied errors into user-friendly messages."""
+
+import json
+import re
+
+from flask import request
+
+# Async-query results are delivered through this endpoint as HTTP 200 with any
+# error embedded in the JSON body, so it must be rewritten despite the 2xx status.
+_ASYNC_EVENT_PATH = "/api/v1/async_event"
+
+# Example:
+#   Access Denied: Cannot select from columns [html_url, login, url, node_id] in table or view users
+_COLUMN_DENIED_PATTERN = re.compile(
+    r"Cannot select from columns \[(?P<columns>[^\]]+)\]\s+in\s+table\s+or\s+view\s+(?P<table>[\w.]+)",
+    re.IGNORECASE,
+)
+
+# Example:
+#   Access Denied: Cannot access catalog sales
+_CATALOG_DENIED_PATTERN = re.compile(
+    r"Cannot access catalog\s+(?P<catalog>[\w-]+)",
+    re.IGNORECASE,
+)
+
+_DENIED_PATTERNS = [
+    re.compile(r"\bPERMISSION_DENIED\b", re.IGNORECASE),
+    re.compile(r"name=PERMISSION_DENIED", re.IGNORECASE),
+    re.compile(r"\bAccess Denied\b", re.IGNORECASE),
+    re.compile(r"\bnot authorized\b", re.IGNORECASE),
+]
+
+
+def _build_request_message(request_url):
+    """Build the "request access" line, optionally pointing at a request URL."""
+    if request_url:
+        return f"Request access:\n {request_url}"
+    return "Request access from your administrator"
+
+
+def _rewrite_permission_denied_string(msg, request_message):
+    """Return a rewritten message for a permission-denied case, else the original."""
+    if not isinstance(msg, str) or not msg.strip():
+        return msg
+
+    m = _COLUMN_DENIED_PATTERN.search(msg)
+    if m:
+        table = (m.group("table") or "").strip()
+        columns = (m.group("columns") or "").strip()
+
+        # Normalize columns formatting a bit
+        columns_clean = (
+            ", ".join([c.strip() for c in columns.split(",") if c.strip()])
+            or columns
+        )
+
+        return (
+            f"Access to one or more restricted columns in '{table}' was blocked.\n\n"
+            f"Restricted columns: {columns_clean}\n\n"
+            f"{request_message}"
+        )
+
+    # Catalog-level denial
+    m = _CATALOG_DENIED_PATTERN.search(msg)
+    if m:
+        catalog = (m.group("catalog") or "").strip()
+        return (
+            f"Access to catalog '{catalog}' is restricted.\n\n"
+            f"{request_message}"
+        )
+
+    # Generic permission denied
+    if any(p.search(msg) for p in _DENIED_PATTERNS):
+        return (
+            "You don’t have access to this dataset.\n\n"
+            f"{request_message}"
+        )
+
+    return msg
+
+
+def _rewrite_any(obj, request_message):
+    """Recursively rewrite denied messages anywhere inside an object.
+
+    Handles dict/list nesting patterns used by:
+    - /api/v1/database/... endpoints (schemas, catalogs, etc.)
+    - /api/v1/sqllab/... endpoints
+    - /api/v1/async_event/ payloads (GLOBAL_ASYNC_QUERIES charts)
+    - legacy /superset/... JSON endpoints, if present
+    """
+    if isinstance(obj, str):
+        return _rewrite_permission_denied_string(obj, request_message)
+
+    if isinstance(obj, list):
+        return [_rewrite_any(x, request_message) for x in obj]
+
+    if isinstance(obj, dict):
+        return {k: _rewrite_any(v, request_message) for k, v in obj.items()}
+
+    return obj
+
+
+def _should_consider_path(path):
+    """Limit rewriting to API-style routes to reduce risk of modifying HTML responses.
+
+    Covers:
+    - /api/v1/... (including /api/v1/async_event/)
+    - /superset/... JSON endpoints (legacy explore/sql lab)
+    """
+    if not path:
+        return False
+    return path.startswith("/api/") or path.startswith("/superset/")
+
+
+def attach_error_rewriter(app, request_url=None):
+    """Register an after_request hook rewriting permission-denied JSON errors.
+
+    Args:
+        app: the Flask application to attach the hook to.
+        request_url: optional URL users are directed to when requesting access.
+    """
+    request_message = _build_request_message(request_url)
+
+    @app.after_request
+    def _rewrite_response(response):
+        try:
+            # Only rewrite JSON-ish payloads.
+            # Use "json" substring to include: application/json,
+            # application/problem+json, etc.
+            ctype = (response.headers.get("Content-Type") or "").lower()
+            if "json" not in ctype:
+                return response
+
+            path = request.path or ""
+            if not _should_consider_path(path):
+                return response
+
+            # Limit scanning to error responses, plus async-event payloads which
+            # carry query errors as HTTP 200 with the error embedded in the body.
+            if response.status_code < 400 and not path.startswith(
+                _ASYNC_EVENT_PATH
+            ):
+                return response
+
+            if getattr(response, "direct_passthrough", False):
+                return response
+
+            payload = response.get_json(silent=True)
+            if payload is None:
+                return response
+
+            new_payload = _rewrite_any(payload, request_message)
+
+            response.set_data(json.dumps(new_payload))
+            response.headers["Content-Length"] = str(len(response.get_data()))
+            return response
+        except Exception:
+            # Never block responses if rewriting fails
+            return response
+
+    return app

--- a/templates/superset_config.py
+++ b/templates/superset_config.py
@@ -293,9 +293,9 @@ SQLALCHEMY_DATABASE_URI = os.getenv("SQL_ALCHEMY_URI")
 # OAUTH configuration
 required_auth_vars = ["GOOGLE_KEY", "GOOGLE_SECRET", "OAUTH_DOMAIN"]
 
+CUSTOM_SECURITY_MANAGER = CustomSsoSecurityManager
 if all(os.getenv(var) for var in required_auth_vars):
     AUTH_TYPE = AUTH_OAUTH
-    CUSTOM_SECURITY_MANAGER = CustomSsoSecurityManager
     OAUTH_PROVIDERS = [
         {
             "name": "google",

--- a/templates/superset_config.py
+++ b/templates/superset_config.py
@@ -3,6 +3,7 @@ from cachelib.redis import RedisCache
 from celery.schedules import crontab
 from flask_appbuilder.security.manager import AUTH_OAUTH
 from custom_sso_security_manager import CustomSsoSecurityManager
+from permission_error_messages import attach_error_rewriter
 from sentry_interceptor import redact_params
 from superset.stats_logger import StatsdStatsLogger
 import sentry_sdk
@@ -342,6 +343,9 @@ MAX_CONTENT_LENGTH = int(v) if (v := os.getenv("MAX_CONTENT_LENGTH")) else None
 MAX_FORM_MEMORY_SIZE = int(v) if (v := os.getenv("MAX_FORM_MEMORY_SIZE")) else 500_000
 MAX_FORM_PARTS = int(v) if (v := os.getenv("MAX_FORM_PARTS")) else 1000
 
+# URL users are directed to when they hit a Trino/Ranger permission-denied error.
+DATA_ACCESS_REQUEST_URL = os.getenv("DATA_ACCESS_REQUEST_URL")
+
 def FLASK_APP_MUTATOR(app):
     """Override the Flask app dynamically."""
 
@@ -353,6 +357,9 @@ def FLASK_APP_MUTATOR(app):
 
     # Swap the default Request class with our configured one
     app.request_class = ConfiguredLimitRequest
+
+    # Rewrite Trino/Ranger permission-denied errors into user-friendly messages
+    attach_error_rewriter(app, request_url=DATA_ACCESS_REQUEST_URL)
 
 
 # =============================================================================

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -122,6 +122,7 @@ class TestCharm(TestCase):
                         "MAX_CONTENT_LENGTH": None,
                         "MAX_FORM_MEMORY_SIZE": None,
                         "MAX_FORM_PARTS": None,
+                        "DATA_ACCESS_REQUEST_URL": None,
                     },
                     "on-check-failure": {"up": "ignore"},
                 }
@@ -221,6 +222,7 @@ class TestCharm(TestCase):
                         "MAX_CONTENT_LENGTH": None,
                         "MAX_FORM_MEMORY_SIZE": None,
                         "MAX_FORM_PARTS": None,
+                        "DATA_ACCESS_REQUEST_URL": None,
                     },
                     "on-check-failure": {"up": "ignore"},
                 },

--- a/tests/unit/test_permission_error_messages.py
+++ b/tests/unit/test_permission_error_messages.py
@@ -1,0 +1,247 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for the permission-denied error message rewriter.
+
+The rewriter lives in templates/permission_error_messages.py and is loaded by
+every Superset process at startup via PYTHONPATH. These tests stub out Flask so
+the module can be imported and exercised with no installed Flask/Superset
+package or running Juju model required.
+"""
+
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+
+# ---------------------------------------------------------------------------
+# Bootstrap: import the module with a stubbed `flask` package
+# ---------------------------------------------------------------------------
+
+_request_stub = types.SimpleNamespace(path="")
+_flask_stub = types.ModuleType("flask")
+setattr(_flask_stub, "request", _request_stub)
+sys.modules.setdefault("flask", _flask_stub)
+
+_MODULE_PATH = (
+    pathlib.Path(__file__).parent.parent.parent
+    / "templates"
+    / "permission_error_messages.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "permission_error_messages", _MODULE_PATH
+)
+assert _spec is not None and _spec.loader is not None
+pem = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pem)
+
+
+# ---------------------------------------------------------------------------
+# Test doubles for the Flask app/response used by attach_error_rewriter
+# ---------------------------------------------------------------------------
+
+
+class _FakeApp:
+    """Captures the after_request hook so tests can invoke it directly.
+
+    Attrs:
+        hook: the function registered via after_request.
+    """
+
+    def __init__(self):
+        """Initialise with no hook registered."""
+        self.hook = None
+
+    def after_request(self, func):
+        """Store the registered hook and return it unchanged.
+
+        Args:
+            func: the after_request callback.
+
+        Returns:
+            The callback, unchanged.
+        """
+        self.hook = func
+        return func
+
+
+class _FakeResponse:
+    """Minimal stand-in for a Flask response object.
+
+    Attrs:
+        status_code: the HTTP status code of the response.
+        headers: the response headers.
+        direct_passthrough: whether the response streams data directly.
+    """
+
+    def __init__(
+        self, payload, status_code=200, content_type="application/json"
+    ):
+        """Initialise with a JSON payload and metadata.
+
+        Args:
+            payload: the object returned by get_json.
+            status_code: the HTTP status code.
+            content_type: the Content-Type header value.
+        """
+        self._payload = payload
+        self._data = b""
+        self.status_code = status_code
+        self.headers = {"Content-Type": content_type}
+        self.direct_passthrough = False
+
+    def get_json(self, silent=False):
+        """Return the stored payload.
+
+        Args:
+            silent: ignored; present for API compatibility.
+
+        Returns:
+            The stored payload.
+        """
+        return self._payload
+
+    def get_data(self):
+        """Return the bytes set via set_data.
+
+        Returns:
+            The stored response body bytes.
+        """
+        return self._data
+
+    def set_data(self, data):
+        """Store the response body.
+
+        Args:
+            data: the new body, as str or bytes.
+        """
+        self._data = data.encode() if isinstance(data, str) else data
+
+
+class TestRequestMessage(unittest.TestCase):
+    """The "request access" line reflects the configured URL."""
+
+    def test_with_url(self):
+        """A configured URL appears in the request-access message."""
+        msg = pem._build_request_message("https://example.com/request")
+        self.assertIn("https://example.com/request", msg)
+
+    def test_without_url_falls_back_to_admin(self):
+        """An unset URL yields the contact-administrator message."""
+        self.assertEqual(
+            pem._build_request_message(None),
+            "Request access from your administrator",
+        )
+
+
+REQ = "Request access from your administrator"
+
+
+class TestRewriteString(unittest.TestCase):
+    """Permission-denied strings are rewritten; others pass through."""
+
+    def test_column_denied(self):
+        """A column-level denial names the table and restricted columns."""
+        msg = (
+            "Access Denied: Cannot select from columns "
+            "[html_url, login] in table or view users"
+        )
+        out = pem._rewrite_permission_denied_string(msg, REQ)
+        self.assertIn("restricted columns in 'users'", out)
+        self.assertIn("html_url, login", out)
+        self.assertIn(REQ, out)
+
+    def test_catalog_denied(self):
+        """A catalog-level denial names the restricted catalog."""
+        msg = "Access Denied: Cannot access catalog sales"
+        out = pem._rewrite_permission_denied_string(msg, REQ)
+        self.assertIn("catalog 'sales'", out)
+        self.assertIn(REQ, out)
+
+    def test_generic_permission_denied(self):
+        """Generic denial markers map to the default dataset message."""
+        for msg in ("PERMISSION_DENIED", "User is not authorized"):
+            out = pem._rewrite_permission_denied_string(msg, REQ)
+            self.assertIn("don’t have access to this dataset", out)
+
+    def test_non_denied_unchanged(self):
+        """A non-permission error is returned unchanged."""
+        msg = "Query timed out after 30 seconds"
+        self.assertEqual(pem._rewrite_permission_denied_string(msg, REQ), msg)
+
+    def test_rewrite_any_nested(self):
+        """Denied strings nested in dicts/lists are rewritten in place."""
+        payload = {"errors": [{"message": "Cannot access catalog sales"}]}
+        out = pem._rewrite_any(payload, REQ)
+        self.assertIn("catalog 'sales'", out["errors"][0]["message"])
+
+
+class TestHookGating(unittest.TestCase):
+    """The after_request hook only rewrites the intended responses."""
+
+    def setUp(self):
+        """Register the hook on a fake app and capture it."""
+        self.app = _FakeApp()
+        pem.attach_error_rewriter(self.app, request_url=None)
+        self.hook = self.app.hook
+
+    def _run(self, response, path):
+        """Invoke the hook for a response on a given request path.
+
+        Args:
+            response: the fake response to pass through the hook.
+            path: the request path to simulate.
+
+        Returns:
+            The (possibly mutated) response.
+        """
+        _request_stub.path = path
+        return self.hook(response)
+
+    def test_error_response_rewritten(self):
+        """A 4xx JSON error on an API path is rewritten."""
+        resp = _FakeResponse(
+            {"message": "Cannot access catalog sales"}, status_code=403
+        )
+        self._run(resp, "/api/v1/chart/data")
+        self.assertIn("catalog 'sales'", resp.get_data().decode())
+
+    def test_async_event_200_rewritten(self):
+        """An async-event 200 with an embedded error is rewritten."""
+        resp = _FakeResponse(
+            {"message": "Cannot access catalog sales"}, status_code=200
+        )
+        self._run(resp, "/api/v1/async_event/")
+        self.assertIn("catalog 'sales'", resp.get_data().decode())
+
+    def test_successful_non_async_response_untouched(self):
+        """A 2xx non-async response is left untouched."""
+        resp = _FakeResponse(
+            {"message": "Cannot access catalog sales"}, status_code=200
+        )
+        self._run(resp, "/api/v1/chart/data")
+        # Hook returned early without re-serialising the body.
+        self.assertEqual(resp.get_data(), b"")
+
+    def test_non_json_untouched(self):
+        """A non-JSON response is left untouched."""
+        resp = _FakeResponse(
+            {"message": "Cannot access catalog sales"},
+            status_code=500,
+            content_type="text/html",
+        )
+        self._run(resp, "/api/v1/chart/data")
+        self.assertEqual(resp.get_data(), b"")
+
+    def test_non_api_path_untouched(self):
+        """A response on a non-API path is left untouched."""
+        resp = _FakeResponse(
+            {"message": "Cannot access catalog sales"}, status_code=500
+        )
+        self._run(resp, "/static/something")
+        self.assertEqual(resp.get_data(), b"")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR updates the Superset charm "permission denied" error messages to a more user-friendly version, including a configurable data access request URL. It picks up the work started in this [PR](https://github.com/canonical/superset-k8s-operator/pull/93).

Tested locally:
<img width="762" height="485" alt="image" src="https://github.com/user-attachments/assets/e18fc700-c08d-4cd8-8e22-7dda664a22da" />

It also fixes the "There was an error loading permissions" error when trying to edit roles by applying the workaround suggested in the issue upstream since the error is still present in v6.1.
<img width="1920" height="1253" alt="image" src="https://github.com/user-attachments/assets/0d84299c-b8f9-42a2-adc5-db39fc99b05e" />
