### PR TITLE
chore: update health check endpoint

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -545,7 +545,7 @@ class SupersetK8SCharm(TypedCharmBase[CharmConfig]):
                         "up": {
                             "override": "replace",
                             "period": "10s",
-                            "http": {"url": "http://localhost:8088/"},
+                            "http": {"url": "http://localhost:8088/health"},
                         }
                     }
                 },


### PR DESCRIPTION
This PR updates the health check endpoint from `/` to `health`. `/` redirects to Superset's welcome page which logs a `welcome` action in the log table that makes up 40% of the entire log records causing performance issues when trying to read from the table.

Solves https://warthogs.atlassian.net/browse/CSS-23487.