### PR TITLE
update pytest and black version in tox to support ast.Str present in python 3.13+

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ description = Run integration tests
 deps =
     ipdb==0.13.9
     juju==3.5.2.1
-    pytest==7.4.0
+    pytest==8.0.0
     pytest-asyncio==0.21
     pytest-operator==0.29.0
     celery==5.3.6
@@ -43,7 +43,7 @@ description = Run integration tests
 deps =
     ipdb==0.13.9
     juju==3.5.2.1
-    pytest==7.4.0
+    pytest==8.0.0
     pytest-asyncio==0.21
     pytest-operator==0.29.0
     celery==5.3.6
@@ -57,7 +57,7 @@ description = Run integration tests
 deps =
     ipdb==0.13.9
     juju==3.5.2.1
-    pytest==7.4.0
+    pytest==8.0.0
     pytest-asyncio==0.21
     pytest-operator==0.29.0
     celery==5.3.6
@@ -71,7 +71,7 @@ description = Run integration tests
 deps =
     ipdb==0.13.9
     juju==3.5.2.1
-    pytest==7.4.0
+    pytest==8.0.0
     pytest-asyncio==0.21
     pytest-operator==0.29.0
     celery==5.3.6
@@ -86,7 +86,7 @@ description = Run Trino catalog integration tests
 deps =
     ipdb==0.13.9
     juju==3.5.2.1
-    pytest==7.4.0
+    pytest==8.0.0
     pytest-asyncio==0.21
     pytest-operator==0.29.0
     celery==5.3.6
@@ -101,7 +101,7 @@ description = Run tests
 deps =
     coverage[toml]==6.4.4
     ipdb==0.13.9
-    pytest==7.1.3
+    pytest==8.0.0
     psycopg2-binary==2.9.9
     -r{toxinidir}/requirements.txt
 commands =
@@ -129,7 +129,7 @@ commands =
 [testenv:fmt]
 description = Format the code
 deps =
-    black==22.8.0
+    black==25.1.0
     isort==5.10.1
 commands =
     isort {[vars]src_path} {[vars]tst_path}
@@ -142,7 +142,7 @@ deps =
     pylint
     pydocstyle
     pytest
-    black==22.8.0
+    black==25.1.0
     codespell==2.2.1
     flake8==7.0.0
     flake8-builtins==3.0.0


### PR DESCRIPTION
## Description

CI runner image has been updated to Python 3.14, updating tool versions in tox.ini to support newer python versions.

Fixes _JIRA/GitHub issue number_

## Engineering checklist
_Check only items that apply_

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Independent change*

 _* This is an independent change if it can be merged and released independently without any related service deployments._

## Merging instructions

The preferred way of merging:
- [ ] Merge
- [ ] Squash and Merge
- [x] Rebase and Merge

## Test instructions

_(optional)_ Describe any non-standard test instructions and configuration settings. Delete this section if not applicable.

## Notes for code reviewers

_(optional)_ Mention any relevant information for code reviewers. Delete this section if not applicable.
